### PR TITLE
Bump Keycloak version from 22.0.5 to 23.0.3

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=22.0.5
+ARG KEYCLOAK_VERSION=23.0.3
 
 FROM alpine as downloader
 ARG KEYCLOAK_VERSION


### PR DESCRIPTION
- https://github.com/keycloak/keycloak/releases/tag/23.0.3
- https://www.keycloak.org/docs/latest/release_notes/index.html#keycloak-23-0-0