### PR TITLE
The `--proxy` option was deprecated since Keycloak 24.0.0

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -16,7 +16,7 @@ services:
       # https://www.keycloak.org/server/all-config
       KC_HOSTNAME: auth.dev.local
       KC_HTTP_ENABLED: 'true'
-      KC_PROXY: edge
+      KC_PROXY_HEADERS: xforwarded
     labels:
       - traefik.enable=true
       - traefik.http.routers.keycloak.entrypoints=websecure


### PR DESCRIPTION
- https://www.keycloak.org/docs/24.0.0/upgrading/#deprecated-proxy-option