### PR TITLE
Bump keycloak from 24.0.3 to 24.0.4

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=24.0.3
+ARG KEYCLOAK_VERSION=24.0.4
 
 FROM alpine as downloader
 ARG KEYCLOAK_VERSION


### PR DESCRIPTION
https://github.com/keycloak/keycloak/releases/tag/24.0.4