### PR TITLE
Bump keycloak from 24.0.5 to 25.0.1

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=24.0.5
+ARG KEYCLOAK_VERSION=25.0.1
 
 FROM alpine as downloader
 ARG KEYCLOAK_VERSION


### PR DESCRIPTION
- https://github.com/keycloak/keycloak/releases/tag/25.0.1