### PR TITLE
Bump keycloak from 25.0.4 to 25.0.6

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=25.0.4
+ARG KEYCLOAK_VERSION=25.0.6
 
 FROM alpine as downloader
 ARG KEYCLOAK_VERSION

--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,7 +1,7 @@
 # https://www.keycloak.org/server/containers
 ARG KEYCLOAK_VERSION=25.0.6
 
-FROM alpine as downloader
+FROM alpine AS downloader
 ARG KEYCLOAK_VERSION
 RUN set -eux; \
     apk add curl; \


### PR DESCRIPTION
- https://github.com/keycloak/keycloak/releases/tag/25.0.6