### PR TITLE
Bump keycloak from 25.0.6 to 26.0.0

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,12 +1,11 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=25.0.6
+ARG KEYCLOAK_VERSION=26.0.0
 
-FROM alpine AS downloader
+# https://hub.docker.com/_/buildpack-deps
+FROM buildpack-deps:curl AS downloader
 ARG KEYCLOAK_VERSION
-RUN set -eux; \
-    apk add --no-cache curl; \
-    # https://github.com/jacekkow/keycloak-protocol-cas
-    curl -Lo /tmp/keycloak-protocol-cas.jar https://github.com/jacekkow/keycloak-protocol-cas/releases/download/${KEYCLOAK_VERSION}/keycloak-protocol-cas-${KEYCLOAK_VERSION}.jar;
+# https://github.com/jacekkow/keycloak-protocol-cas
+RUN curl -Lo /tmp/keycloak-protocol-cas.jar https://github.com/jacekkow/keycloak-protocol-cas/releases/download/${KEYCLOAK_VERSION}/keycloak-protocol-cas-${KEYCLOAK_VERSION}.jar;
 
 # https://github.com/keycloak/keycloak/tree/main/quarkus/container
 # https://quay.io/repository/keycloak/keycloak?tab=tags


### PR DESCRIPTION
- https://github.com/keycloak/keycloak/releases/tag/26.0.0