### PR TITLE
Bump keycloak from 26.0.1 to 26.0.2

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=26.0.1
+ARG KEYCLOAK_VERSION=26.0.2
 
 # https://github.com/keycloak/keycloak/tree/main/quarkus/container
 # https://quay.io/repository/keycloak/keycloak?tab=tags
@@ -9,5 +9,7 @@ ARG KEYCLOAK_VERSION
 # add CAS protocol for Keycloak
 # https://github.com/jacekkow/keycloak-protocol-cas
 ADD --chown=keycloak:keycloak https://github.com/jacekkow/keycloak-protocol-cas/releases/download/${KEYCLOAK_VERSION}/keycloak-protocol-cas-${KEYCLOAK_VERSION}.jar /opt/keycloak/providers/keycloak-protocol-cas.jar
+
+WORKDIR /opt/keycloak
 
 RUN /opt/keycloak/bin/kc.sh build


### PR DESCRIPTION
- https://github.com/keycloak/keycloak/releases/tag/26.0.2