### PR TITLE
Upgrade Keycloak and CAS protocol to version 26.6.3

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,6 +1,7 @@
-# https://github.com/keycloak/keycloak/releases
-ARG KEYCLOAK_VERSION=26.6.2
-ARG KEYCLOAK_CAS_VERSION=26.6.2
+# https://github.com/keycloak/keycloak/releases/tag/26.6.3
+ARG KEYCLOAK_VERSION=26.6.3
+# https://github.com/jacekkow/keycloak-protocol-cas/releases/tag/26.6.3
+ARG KEYCLOAK_CAS_VERSION=26.6.3
 FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}
 ARG KEYCLOAK_VERSION
 ARG KEYCLOAK_CAS_VERSION


### PR DESCRIPTION
## Summary
Updates the Keycloak Docker image and the Keycloak CAS protocol extension to version 26.6.3 in the development container configuration.

## Key Changes
- Updated `KEYCLOAK_VERSION` from 26.6.2 to 26.6.3
- Updated `KEYCLOAK_CAS_VERSION` from 26.6.2 to 26.6.3
- Added specific release tag references in comments for both Keycloak and the CAS protocol extension for better traceability

## Implementation Details
The changes ensure the development environment uses the latest patch version of Keycloak and maintains version parity with the CAS protocol extension, which is critical for compatibility between the two components.

https://claude.ai/code/session_01CrgUnZWwFMRJB4DTquy4n3