### PR TITLE
build: implement mise config with precompiled php and aube

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,33 +84,26 @@ jobs:
         run: .devcontainer/joomla/install.sh
 
       # E2E test preparation
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Setup mise
+        uses: jdx/mise-action@v4
         with:
-          node-version: '24'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable Corepack
-        run: corepack enable pnpm
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Cache pnpm store
+      - name: Cache Aube store
         uses: actions/cache@v5
         with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('e2e/pnpm-lock.yaml') }}
+          path: ~/.local/share/aube/store/v1
+          key: ${{ runner.os }}-aube-store-${{ hashFiles('e2e/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-aube-store-
 
       - name: Install E2E dependencies
         working-directory: e2e
-        run: pnpm install
+        run: aube install
 
       - name: Get Playwright version
         working-directory: e2e
-        run: echo "PLAYWRIGHT_VERSION=$(pnpm exec playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_VERSION=$(aubx playwright --version | cut -d' ' -f2)" >> $GITHUB_ENV
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -124,15 +117,15 @@ jobs:
         run: |
           if [ "${{ steps.playwright-cache.outputs.cache-hit }}" != 'true' ]; then
             echo "Cache miss - Installing browsers with system dependencies..."
-            pnpm exec playwright install --with-deps chromium
+            aubx playwright install --with-deps chromium
           else
             echo "Cache hit - Installing system dependencies only..."
-            pnpm exec playwright install-deps chromium
+            aubx playwright install-deps chromium
           fi
 
       - name: Run E2E tests
         working-directory: e2e
-        run: pnpm test
+        run: aubr test
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ Thumbs.db
 /dist/
 .claude/
 .agent/
+
+# mise
+.mise.local.toml
+.mise/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,13 @@
 - TLS certificates: run `.devcontainer/generate-certs.sh .devcontainer/.secrets`.
 - Access URLs: Joomla at `https://www.dev.local`, Keycloak at `https://auth.dev.local`.
 
+## Environment & Tooling
+
+This repository uses [mise](https://mise.jdx.dev/) to manage development runtimes and CLI versions (PHP, Composer, Node.js, and Aube).
+
+- To install the project's development tools, run: `mise install`
+- Runtimes are configured in [mise.toml](mise.toml) (using `adwinying/php` for precompiled static PHP binaries).
+
 ## Essential Commands
 
 ```sh
@@ -57,7 +64,7 @@ composer run phpstan      # static analysis
 ## Subdirectory Guides
 
 - [.devcontainer/AGENTS.md](.devcontainer/AGENTS.md) — Dev container, extension management, diagnostics
-- [e2e/AGENTS.md](e2e/AGENTS.md) — E2E testing with Playwright (`pnpm` required)
+- [e2e/AGENTS.md](e2e/AGENTS.md) — E2E testing with Playwright (`aube` required)
 
 ## Claude Code Compatibility
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -2,23 +2,23 @@
 
 End-to-end tests use [Playwright](https://playwright.dev/).
 
-**IMPORTANT: Always use `pnpm`, NOT `npm`.**
+**IMPORTANT: Always use `aube` (the Aube package manager), NOT `npm`.**
 
 ## Prerequisites
 
 - Dev container services must be running with HTTPS enabled
-- Node.js and pnpm installed
+- Development tools installed via mise (`mise install`); see the root [AGENTS.md](../AGENTS.md) "Environment & Tooling" section
 
 ## Commands
 
 ```sh
 cd e2e
 
-pnpm install              # install dependencies
-pnpm test                 # run tests (headless)
-pnpm test:headed          # run tests (browser visible)
-pnpm test -- --grep <pattern>  # run specific tests
-pnpm test:debug           # debug tests
-pnpm test:ui              # interactive UI mode
-pnpm report               # view HTML report
+aube install              # install dependencies
+aubr test                 # run tests (headless)
+aubr test:headed          # run tests (browser visible)
+aubr test -- --grep <pattern>  # run specific tests
+aubr test:debug           # debug tests
+aubr test:ui              # interactive UI mode
+aubr report               # view HTML report
 ```

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -2,7 +2,6 @@
   "name": "joomla-external-login-e2e",
   "version": "1.0.0",
   "private": true,
-  "packageManager": "pnpm@11.4.0",
   "description": "E2E tests for Joomla External Login extension",
   "scripts": {
     "test": "playwright test",

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+"github:adwinying/php" = "8.4"
+"github:composer/composer" = { version = "latest", postinstall = "mv \"$MISE_TOOL_INSTALL_PATH/composer.phar\" \"$MISE_TOOL_INSTALL_PATH/composer\" && chmod +x \"$MISE_TOOL_INSTALL_PATH/composer\"" }
+node = "lts"
+aube = "latest"


### PR DESCRIPTION
## Summary

Adopt [mise](https://mise.jdx.dev/) + the [Aube](https://github.com/) package manager for development tooling, mirroring akunzai/MageBridgeCore#193.

- Add `mise.toml` pinning PHP 8.4 (precompiled via `github:adwinying/php`), Composer (with a `postinstall` that renames `composer.phar` → `composer`), Node.js LTS, and Aube.
- Switch the E2E workflow from `actions/setup-node` + corepack/pnpm to `jdx/mise-action@v4` with an Aube store cache; replace pnpm commands with the Aube toolchain (`aube install` / `aubx` / `aubr`).
- Drop the `packageManager` pin from `e2e/package.json`.
- Ignore mise local files (`.mise.local.toml`, `.mise/`).
- Update `AGENTS.md` and `e2e/AGENTS.md` to document the mise/Aube workflow.

`pnpm-lock.yaml` is retained — Aube reads it natively and the workflow cache key still hashes it.

## Verification

Validated locally with mise `2026.6.14`:

- `mise.toml` resolves all four tools (php 8.4.22, composer 2.10.1, node 24 LTS, aube 1.25.1).
- `aube install` reads the existing `pnpm-lock.yaml` without rewriting it.
- `aubx playwright --version` → `Version 1.60.0` (the workflow's `cut -d' ' -f2` yields `1.60.0`).
- `aubr test --list` resolves 29 tests across 7 files.
- `.github/workflows/e2e.yml` passes YAML validation.

`jdx/mise-action@v4` behavior on the GitHub runner will be confirmed by CI.