### PR TITLE
chore: upgrade Joomla to 6.1.2 and 5.4.7

### DIFF
--- a/.devcontainer/joomla/Dockerfile
+++ b/.devcontainer/joomla/Dockerfile
@@ -1,7 +1,7 @@
 ARG PHP_VERSION=8.4
 ARG PHP_EXTRA_BUILD_DEPS=""
 # https://hub.docker.com/_/joomla
-ARG JOOMLA_VERSION=6.1.1
+ARG JOOMLA_VERSION=6.1.2
 
 FROM joomla:${JOOMLA_VERSION}-apache AS joomla
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
         joomla:
           - version: "5"
             php-version: "8.3"
-            joomla-version: "5.4.6"
+            joomla-version: "5.4.7"
           - version: "6"
             php-version: ""
             joomla-version: ""

--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,15 @@
 			"type": "package",
 			"package": {
 				"name": "joomla/joomla-cms",
-				"version": "6.1.1",
+				"version": "6.1.2",
 				"dist": {
-					"url": "https://github.com/joomla/joomla-cms/releases/download/6.1.1/Joomla_6.1.1-Stable-Full_Package.zip",
+					"url": "https://github.com/joomla/joomla-cms/releases/download/6.1.2/Joomla_6.1.2-Stable-Full_Package.zip",
 					"type": "zip"
 				},
 				"source": {
 					"url": "https://github.com/joomla/joomla-cms.git",
 					"type": "git",
-					"reference": "tags/6.1.1"
+					"reference": "tags/6.1.2"
 				}
 			}
 		}
@@ -45,7 +45,7 @@
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.95",
-		"joomla/joomla-cms": "6.1.1",
+		"joomla/joomla-cms": "6.1.2",
 		"phpstan/extension-installer": "^1.4",
 		"phpstan/phpstan": "^2.1",
 		"phpstan/phpstan-deprecation-rules": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "312f86ed4fafa8e296069686f4e342a1",
+    "content-hash": "c2069b142b58e40ba1d7f78b85aa448c",
     "packages": [],
     "packages-dev": [
         {
@@ -574,15 +574,15 @@
         },
         {
             "name": "joomla/joomla-cms",
-            "version": "6.1.1",
+            "version": "6.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla/joomla-cms.git",
-                "reference": "tags/6.1.1"
+                "reference": "tags/6.1.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/joomla/joomla-cms/releases/download/6.1.1/Joomla_6.1.1-Stable-Full_Package.zip"
+                "url": "https://github.com/joomla/joomla-cms/releases/download/6.1.2/Joomla_6.1.2-Stable-Full_Package.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
## Summary
- Bump the pinned `joomla/joomla-cms` package (composer repository definition + `require-dev`) from `6.1.1` to `6.1.2`
- Update `.devcontainer/joomla/Dockerfile` default `JOOMLA_VERSION` build arg to `6.1.2`
- Update the Joomla 5 E2E matrix leg in `.github/workflows/e2e.yml` from `5.4.6` to `5.4.7`
- Regenerate `composer.lock` to match

References:
- https://github.com/joomla/joomla-cms/releases/tag/6.1.2
- https://github.com/joomla/joomla-cms/releases/tag/5.4.7

## Test plan
- [x] `composer validate --strict` passes
- [ ] E2E workflow passes for both Joomla 5 and Joomla 6 matrix legs


---
_Generated by [Claude Code](https://claude.ai/code/session_01K52LKhxa2aeJBMVaaNDCBV)_