### PR TITLE
docs: standardize AGENTS.md as index-driven entrypoint

### DIFF
--- a/.devcontainer/AGENTS.md
+++ b/.devcontainer/AGENTS.md
@@ -1,6 +1,6 @@
-# Agent Guidelines for Dev Container
+# Dev Container — Agent Guidelines
 
-See [README.md](README.md) for full setup instructions including requirements, credentials, and URLs.
+**Context-offloaded SOP** for the compose stack. Human setup/credentials: @.devcontainer/README.md. Root index: @AGENTS.md.
 
 ## Starting the Stack
 
@@ -16,28 +16,26 @@ docker compose -f .devcontainer/compose.yml down
 
 ## Working Inside the Container
 
-Prefix project tasks with:
-
 ```sh
 docker compose -f .devcontainer/compose.yml exec -w /workspace joomla <command>
 ```
 
-### Common Tasks
+Common tasks (script SSOT: @composer.json):
 
 ```sh
-composer install                # install dependencies
-composer update                 # update dependencies
-composer run lint               # check code style (dry-run)
-composer run fix                # auto-fix code style
-composer run phpstan            # static analysis
-composer run phpstan-baseline   # update PHPStan baseline
-composer validate --strict      # validate metadata
-./bundle.sh                     # bundle release
+composer install
+composer update
+composer run lint
+composer run fix
+composer run phpstan
+composer run phpstan-baseline
+composer validate --strict
+./bundle.sh
 ```
 
 ## Managing the Joomla Extension
 
-These commands run inside the container (no `-w /workspace` needed):
+Run inside the container (no `-w /workspace`):
 
 ```sh
 # Install
@@ -50,28 +48,21 @@ php /var/www/html/cli/joomla.php extension:list | grep -iE '(external|caslogin)'
 bash -c "php /var/www/html/cli/joomla.php extension:list | grep -iE '(external|caslogin)' | awk '{print \$2}' | xargs -I{} php /var/www/html/cli/joomla.php extension:remove -n {}"
 ```
 
-## Quick File Copy for Rapid Testing
+## Quick File Copy (rapid iteration)
 
-Skip full reinstall by copying files directly:
+Skip full reinstall; copy then clear cache:
 
 ```sh
-# Copy single PHP file
 docker compose -f .devcontainer/compose.yml cp src/plugins/system/caslogin/src/Extension/Caslogin.php joomla:/var/www/html/plugins/system/caslogin/src/Extension/Caslogin.php
-
-# Copy directory
 docker compose -f .devcontainer/compose.yml cp src/plugins/system/caslogin/language joomla:/var/www/html/plugins/system/caslogin/
-
-# Copy component template
 docker compose -f .devcontainer/compose.yml cp src/administrator/components/com_externallogin/tmpl/servers/default.php joomla:/var/www/html/administrator/components/com_externallogin/tmpl/servers/default.php
-
-# Clear cache after copying
 docker compose -f .devcontainer/compose.yml exec joomla php /var/www/html/cli/joomla.php cache:clean
 ```
 
 ## Diagnosing Issues
 
 ```sh
-# Joomla error logs
+# Joomla error logs (inside container FS layout)
 tail -20 /www/html/administrator/logs/everything.php
 
 # Container logs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,74 +1,61 @@
-# Agent Guidelines for Joomla External Login
+# Joomla External Login — Agent Guidelines
 
-## Documentation Principles
+**Index-driven entrypoint.** Prefer **Progressive Disclosure**: keep this file lean; **Context Offload** multi-step SOPs to nested guides via **Lazy Loading** (`@path`). **Trust model judgment** for generic coding practice; record only project-specific, non-derivable constraints.
 
-1. **This file records only essential knowledge.** Advanced or complex topics should be split into subdirectory `AGENTS.md` files or relevant `README.md` files by domain.
-2. **Use subdirectory `AGENTS.md` to organize domain-specific knowledge.** For example, `e2e/AGENTS.md` for testing, `.devcontainer/AGENTS.md` for dev environment.
-3. **Record valuable knowledge back to related files** when solving problems or discovering useful patterns.
-4. **All files and code must be written in English.**
+## Quick Commands
 
-## Environment Quick Facts
-
-- Use the VS Code dev container; see [.devcontainer/AGENTS.md](.devcontainer/AGENTS.md) for detailed commands.
-- Services expose Traefik `443` and MySQL `3306`.
-- TLS certificates: run `.devcontainer/generate-certs.sh .devcontainer/.secrets`.
-- Access URLs: Joomla at `https://www.dev.local`, Keycloak at `https://auth.dev.local`.
-
-## Environment & Tooling
-
-This repository uses [mise](https://mise.jdx.dev/) to manage development runtimes and CLI versions (PHP, Composer, Node.js, and Aube).
-
-- To install the project's development tools, run: `mise install`
-- Runtimes are configured in [mise.toml](mise.toml) (using `adwinying/php` for precompiled static PHP binaries).
-
-## Essential Commands
+Toolchain SSOT: @mise.toml — run `mise install` for PHP, Composer, Node, Aube.
 
 ```sh
-# Start / stop stack
+# Stack (full SOP: @.devcontainer/AGENTS.md)
 docker compose -f .devcontainer/compose.yml up -d
-docker compose -f .devcontainer/compose.yml down
-
-# Work inside the container
 docker compose -f .devcontainer/compose.yml exec -w /workspace joomla <command>
 
-# Common tasks (inside container)
-composer install          # install dependencies
-composer run lint         # check code style (dry-run)
-composer run fix          # auto-fix code style
-composer run phpstan      # static analysis
-./bundle.sh              # bundle release
+# Quality / release (script SSOT: @composer.json)
+composer install
+composer run lint       # php-cs-fixer dry-run
+composer run fix
+composer run phpstan
+./bundle.sh             # → dist/pkg_externallogin.zip
 ```
 
-## Architecture Overview
+**Dev endpoints:** Joomla `https://www.dev.local` · Keycloak `https://auth.dev.local` · Traefik `443` · MySQL `3306`. TLS: `.devcontainer/generate-certs.sh .devcontainer/.secrets`.
 
-- `src/`: Main source code for the Joomla Extension package
-  - `src/administrator/`: Backend component files (admin UI for com_externallogin)
-  - `src/components/`: Frontend component files
-  - `src/plugins/`: Core logic plugins
-    - `src/plugins/authentication/`: Authentication plugins handling login validation
-    - `src/plugins/system/`: System plugins (e.g., caslogin) handling global hooks and SSO routing
-    - `src/plugins/user/`: User plugins handling profile sync or user events
-- `e2e/`: End-to-end tests using Playwright
-- `dist/`: Output directory for bundled zip packages (`pkg_externallogin.zip`)
+## Architecture
 
-## Code Style Highlights
+| Path | Role |
+|------|------|
+| `src/` | Extension package: admin (`administrator/`), site (`components/`), plugins (`plugins/{authentication,system,user}/`) |
+| `e2e/` | Playwright E2E — @e2e/AGENTS.md |
+| `dist/` | Bundled zips (`pkg_externallogin.zip`) |
+| `.devcontainer/` | Compose stack, extension install, diagnostics — @.devcontainer/AGENTS.md |
 
-- Follow PSR-12 with PHP 8.1 migration rules.
-- Import order: `Joomla\CMS` → other Joomla → project namespaces, alphabetically.
-- Use fully qualified strict types and native function casing.
-- Naming: classes PascalCase, methods camelCase, files lowercase_underscores.
-- Maintain Joomla MVC inheritance patterns.
-- Include `defined('_JEXEC') or die;` at PHP entry points.
-- Use Joomla exceptions and `Text` for user-facing messages.
+## Code Style (project-specific)
 
-## Subdirectory Guides
+Machine-enforced SSOT: @.php-cs-fixer.dist.php (`@PSR12`, `@PHP83Migration`). Static analysis: @phpstan.neon.
 
-- [.devcontainer/AGENTS.md](.devcontainer/AGENTS.md) — Dev container, extension management, diagnostics
-- [e2e/AGENTS.md](e2e/AGENTS.md) — E2E testing with Playwright (`aube` required)
+Non-derivable conventions:
+
+- Import order: `Joomla\CMS` → other Joomla → project namespaces (alpha within each group)
+- PHP entry points: `defined('_JEXEC') or die;`
+- User-facing copy: Joomla `Text`; failures: Joomla exceptions
+- Components follow Joomla MVC inheritance
+- All source and docs in English
+
+## Context Offloading
+
+| Domain | Lazy-load |
+|--------|-----------|
+| Dev stack, extension lifecycle, file-copy testing, logs | @.devcontainer/AGENTS.md |
+| E2E (`aube` / Playwright) | @e2e/AGENTS.md |
+
+## Knowledge Writeback
+
+When a durable, non-obvious gotcha appears: propose a **context-tagged** bullet on the nearest relevant `AGENTS.md`. **Active Pruning:** keep any `## Lessons Learned` ≤ 5; drop obsolete version tags; promote durable rules into configs or Rich References rather than prose.
 
 ## Claude Code Compatibility
 
 > [!NOTE]
-> This repository maintains compatibility with Claude Code. The file `CLAUDE.md` is a symbolic link pointing to `AGENTS.md`. 
+> This repository maintains compatibility with Claude Code. The file `CLAUDE.md` is a symbolic link pointing to `AGENTS.md`.
 > All commands, style guides, and workflows defined in `AGENTS.md` apply to both Antigravity (and other agentic assistants) and Claude Code.
 > **DO NOT** delete the `CLAUDE.md` symbolic link or edit it independently; all guidelines must be updated directly in `AGENTS.md`.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -1,24 +1,24 @@
-# Agent Guidelines for E2E Tests
+# E2E Tests — Agent Guidelines
 
-End-to-end tests use [Playwright](https://playwright.dev/).
+**Context-offloaded SOP** for Playwright E2E. Root index: @AGENTS.md.
 
-**IMPORTANT: Always use `aube` (the Aube package manager), NOT `npm`.**
+Use **`aube` only** (not npm/pnpm/yarn). Runner binary is `aubr`.
 
 ## Prerequisites
 
-- Dev container services must be running with HTTPS enabled
-- Development tools installed via mise (`mise install`); see the root [AGENTS.md](../AGENTS.md) "Environment & Tooling" section
+- Compose stack up with HTTPS (@.devcontainer/AGENTS.md)
+- Toolchain: `mise install` (SSOT: @mise.toml)
 
 ## Commands
 
 ```sh
 cd e2e
 
-aube install              # install dependencies
-aubr test                 # run tests (headless)
-aubr test:headed          # run tests (browser visible)
-aubr test -- --grep <pattern>  # run specific tests
-aubr test:debug           # debug tests
-aubr test:ui              # interactive UI mode
-aubr report               # view HTML report
+aube install                    # install dependencies
+aubr test                       # headless
+aubr test:headed                # headed browser
+aubr test -- --grep <pattern>   # single test / filter
+aubr test:debug                 # debug
+aubr test:ui                    # interactive UI
+aubr report                     # HTML report
 ```


### PR DESCRIPTION
## Summary

- Standardize root and nested `AGENTS.md` around **Progressive Disclosure**: lean **index-driven entrypoint**, **Context Offloading** to `.devcontainer/` and `e2e/`, **Lazy Loading** via `@path`.
- Establish **SSOT** pointers (`@mise.toml`, `@composer.json`, `@.php-cs-fixer.dist.php`) instead of duplicated command/style prose.
- Drop micromanagement (generic naming rules) and fix the stale PHP 8.1 migration claim to match `@PHP83Migration`.
- Keep Claude Code compatibility (`CLAUDE.md` → `AGENTS.md` symlink unchanged).

## Quality before → after (root)

| | Before | After |
|---|---|---|
| Grade | B | A target |
| Lines | 74 | ~55 |
| SSOT | Commands/style duplicated | Pointers + non-derivable rules only |
| Currency | PHP 8.1 claim wrong | Aligns with php-cs-fixer |

## Test plan

- [ ] Confirm `CLAUDE.md` still resolves to `AGENTS.md`
- [ ] Spot-check `@path` targets exist
- [ ] Nested guides still list working compose / `aube` commands