### PR TITLE
chore: drop PHP 8.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"require": {
-		"php": ">=8.1"
+		"php": ">=8.3"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.95",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 		}
 	],
 	"require": {
-		"php": ">=8.3"
+		"php": ">=8.3 <9.0"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.95",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c2069b142b58e40ba1d7f78b85aa448c",
+    "content-hash": "57beadbe5043d6a326cfa15acfe7a8e9",
     "packages": [],
     "packages-dev": [
         {
@@ -2929,7 +2929,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.3"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57beadbe5043d6a326cfa15acfe7a8e9",
+    "content-hash": "bbb5eaab3bfa001a9e10cf0b6c390eb2",
     "packages": [],
     "packages-dev": [
         {
@@ -2929,7 +2929,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3"
+        "php": ">=8.3 <9.0"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"


### PR DESCRIPTION
## Summary
- Raise the Composer platform requirement from PHP 8.1 to PHP 8.3.
- Update the lockfile platform metadata accordingly.

This is a breaking release constraint: installations running PHP 8.1 or 8.2 are no longer supported. Keeping it in a dedicated PR makes the release-note entry explicit.

## Verification
- [x] ./composer.json is valid
- [x] Found 0 of 94 files that can be fixed in 0.131 seconds, 18.00 MB memory used
- [x] [OK] No errors                                                                 