### PR TITLE
fix(php): address PHP 8.2 dynamic property deprecation on AuthenticationResponse

### DIFF
--- a/src/administrator/components/com_externallogin/src/Authentication/ExternalAuthenticationResponse.php
+++ b/src/administrator/components/com_externallogin/src/Authentication/ExternalAuthenticationResponse.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @author      Charley Wu <akunzai@gmail.com>
+ * @copyright   Copyright (C) 2008-2026 Christophe Demko, Ioannis Barounis, Alexandre Gandois, Charley Wu. All rights reserved.
+ * @license     GNU General Public License, version 2. http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * @link        https://github.com/akunzai/joomla-external-login
+ */
+
+namespace Joomla\Component\Externallogin\Administrator\Authentication;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Authentication\AuthenticationResponse;
+
+/**
+ * External Login Authentication Response class.
+ * Extends Joomla core AuthenticationResponse with explicit properties
+ * to avoid PHP 8.2+ dynamic property creation deprecation warnings.
+ *
+ * @since 5.2.0
+ */
+class ExternalAuthenticationResponse extends AuthenticationResponse
+{
+    /**
+     * External authentication server configuration object.
+     *
+     * @since 5.2.0
+     */
+    public ?object $server = null;
+
+    /**
+     * Additional response message.
+     *
+     * @since 5.2.0
+     */
+    public string $message = '';
+
+    /**
+     * Group IDs or names assigned to the authenticated user.
+     *
+     * @since 5.2.0
+     */
+    public ?array $groups = null;
+
+    /**
+     * Subtype of external login plugin.
+     *
+     * @since 5.2.0
+     */
+    public string $subtype = '';
+
+    /**
+     * Create an ExternalAuthenticationResponse from a standard AuthenticationResponse.
+     *
+     * @since 5.2.0
+     */
+    public static function fromResponse(AuthenticationResponse $response): self
+    {
+        if ($response instanceof self) {
+            return $response;
+        }
+
+        $new = new self();
+
+        foreach (get_object_vars($response) as $property => $value) {
+            $new->$property = $value;
+        }
+
+        return $new;
+    }
+}

--- a/src/plugins/authentication/externallogin/src/Extension/Externallogin.php
+++ b/src/plugins/authentication/externallogin/src/Extension/Externallogin.php
@@ -26,6 +26,7 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\CMS\User\UserHelper;
+use Joomla\Component\Externallogin\Administrator\Authentication\ExternalAuthenticationResponse;
 use Joomla\Component\Externallogin\Administrator\Service\Logger\ExternalloginLogEntry;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherInterface;
@@ -76,9 +77,8 @@ class Externallogin extends CMSPlugin
         }
 
         // Clone the response
-        $response = clone $response;
+        $response = ExternalAuthenticationResponse::fromResponse(clone $response);
         /** @var Registry */
-        /** @phpstan-ignore-next-line */
         $params = $response->server->params;
         $userId = intval(UserHelper::getUserId($response->username));
         $isUserNotFound = $userId === 0;
@@ -150,6 +150,7 @@ class Externallogin extends CMSPlugin
             return;
         }
 
+        $response = ExternalAuthenticationResponse::fromResponse($response);
         $response->subtype = $response->type;
         $response->type = 'externallogin';
 
@@ -160,14 +161,14 @@ class Externallogin extends CMSPlugin
     }
 
     /**
-     * @param AuthenticationResponse $response
+     * @param ExternalAuthenticationResponse $response
      *
-     * @return AuthenticationResponse
+     * @return ExternalAuthenticationResponse
      */
     private function createNewUser($response)
     {
         /** @var Registry $params */
-        $params = $response->server->params; // @phpstan-ignore property.notFound
+        $params = $response->server->params;
         $isLogAutoRegister = boolval($params->get('log_autoregister', 0));
         $db = Factory::getContainer()->get(DatabaseInterface::class);
         $userFactory = Factory::getContainer()->get(UserFactoryInterface::class);
@@ -180,7 +181,6 @@ class Externallogin extends CMSPlugin
 
         if (!$user->save()) {
             if ($isLogAutoRegister) {
-                /** @phpstan-ignore-next-line */
                 $serverId = $response->server->id;
                 Log::add(
                     new ExternalloginLogEntry(
@@ -206,7 +206,6 @@ class Externallogin extends CMSPlugin
                         . '" and email "'
                         . $response->email
                         . '" on server '
-                        /** @phpstan-ignore-next-line */
                         . $response->server->id,
                     Log::INFO,
                     'authentication-externallogin-autoregister'
@@ -230,7 +229,6 @@ class Externallogin extends CMSPlugin
         $db->execute();
 
         if ($isLogAutoRegister) {
-            /** @phpstan-ignore-next-line */
             $serverId = $response->server->id;
             $message = empty($response->groups)
                 ? 'Auto-register default group "' . $defaultUserGroup . '" for user "' . $user->username . '" on server ' . $serverId
@@ -248,15 +246,14 @@ class Externallogin extends CMSPlugin
     }
 
     /**
-     * @param AuthenticationResponse $response
+     * @param ExternalAuthenticationResponse $response
      * @param int $userId
      *
-     * @return AuthenticationResponse
+     * @return ExternalAuthenticationResponse
      */
     private function updateUser($response, $userId)
     {
         /** @var Registry */
-        /** @phpstan-ignore-next-line */
         $params = $response->server->params;
 
         $isLogAutoUpdate = boolval($params->get('log_autoupdate', 0));
@@ -295,7 +292,6 @@ class Externallogin extends CMSPlugin
             $db->execute();
 
             if ($isLogAutoUpdate) {
-                /** @phpstan-ignore-next-line */
                 $serverId = $response->server->id;
                 $groups = $response->groups;
                 Log::add(
@@ -316,7 +312,6 @@ class Externallogin extends CMSPlugin
 
         // Attempt to update the user
         if ($user->save() && $isLogAutoUpdate) {
-            /** @phpstan-ignore-next-line */
             $serverId = $response->server->id;
             Log::add(
                 new ExternalloginLogEntry(
@@ -355,11 +350,11 @@ class Externallogin extends CMSPlugin
     }
 
     /**
-     * @param AuthenticationResponse $response
+     * @param ExternalAuthenticationResponse $response
      * @param string|null $redirection
      * @param int $status
      *
-     * @return AuthenticationResponse
+     * @return ExternalAuthenticationResponse
      */
     private function userLoginFail(
         $response,
@@ -377,7 +372,7 @@ class Externallogin extends CMSPlugin
     }
 
     /**
-     * @param AuthenticationResponse $response
+     * @param ExternalAuthenticationResponse $response
      * @param int $userId
      * @param bool $isSkipExisting
      */
@@ -395,7 +390,6 @@ class Externallogin extends CMSPlugin
         }
 
         $query = $db->getQuery(true);
-        /** @phpstan-ignore-next-line */
         $serverId = intval($response->server->id);
         $query->insert(
             '#__externallogin_users'

--- a/src/plugins/system/caslogin/src/Extension/Caslogin.php
+++ b/src/plugins/system/caslogin/src/Extension/Caslogin.php
@@ -32,6 +32,7 @@ use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
+use Joomla\Component\Externallogin\Administrator\Authentication\ExternalAuthenticationResponse;
 use Joomla\Component\Externallogin\Administrator\Helper\ExternalloginHelper;
 use Joomla\Component\Externallogin\Administrator\Model\ServersModel;
 use Joomla\Component\Externallogin\Administrator\Service\Logger\ExternalloginLogEntry;
@@ -528,34 +529,42 @@ class Caslogin extends CMSPlugin
             return;
         }
 
+        $extResponse = ExternalAuthenticationResponse::fromResponse($response);
+
         $server = $this->server;
         $params = $server->params;
         $sid = $server->id;
         // @phpstan-ignore assign.propertyType
-        $response->status = Authentication::STATUS_SUCCESS;
-        // @phpstan-ignore property.notFound
-        $response->server = $server;
-        $response->type = 'system.caslogin';
-        // @phpstan-ignore property.notFound
-        $response->message = '';
+        $extResponse->status = Authentication::STATUS_SUCCESS;
+        $extResponse->server = $server;
+        $extResponse->type = 'system.caslogin';
+        $extResponse->message = '';
 
-        $response->username = str_replace(
+        $extResponse->username = str_replace(
             ['<', '>', '"', "'", '%', ';', '(', ')', '&', '\\'],
             '',
             $this->xpath->evaluate($params->get('username_xpath'), $this->success)
         );
 
-        $response->email = str_replace(
+        $extResponse->email = str_replace(
             ['<', '>', '"', "'", '%', ';', '(', ')', '&', '\\'],
             '',
             $this->xpath->evaluate($params->get('email_xpath'), $this->success)
         );
 
-        $response->fullname = $this->xpath->evaluate($params->get('name_xpath'), $this->success);
+        $extResponse->fullname = $this->xpath->evaluate($params->get('name_xpath'), $this->success);
 
+        if ($response !== $extResponse) {
+            // @phpstan-ignore assign.propertyType
+            $response->status = $extResponse->status;
+            $response->type = $extResponse->type;
+            $response->username = $extResponse->username;
+            $response->email = $extResponse->email;
+            $response->fullname = $extResponse->fullname;
+        }
 
         // Set the modified response back to the event
-        $event->setArgument('response', $response);
+        $event->setArgument('response', $extResponse);
 
         if (empty($params->get('group_xpath'))) {
             // Add result to the result array
@@ -575,7 +584,7 @@ class Caslogin extends CMSPlugin
             if ($params->get('log_groups', 0)) {
                 Log::add(
                     new ExternalloginLogEntry(
-                        'Unsuccessful detection of groups for user "' . $response->username . '" on server ' . $sid,
+                        'Unsuccessful detection of groups for user "' . $extResponse->username . '" on server ' . $sid,
                         Log::WARNING,
                         'system-caslogin-groups'
                     )
@@ -596,14 +605,13 @@ class Caslogin extends CMSPlugin
         if ($params->get('log_groups', 0)) {
             Log::add(
                 new ExternalloginLogEntry(
-                    'Successful detection of groups for user "' . $response->username . '" on server ' . $sid,
+                    'Successful detection of groups for user "' . $extResponse->username . '" on server ' . $sid,
                     Log::INFO,
                     'system-caslogin-groups'
                 )
             );
         }
-        // @phpstan-ignore property.notFound
-        $response->groups = [];
+        $extResponse->groups = [];
 
         for ($i = 0; $i < $groups->length; $i++) {
             $group = (string) $groups->item($i)->nodeValue;
@@ -612,7 +620,7 @@ class Caslogin extends CMSPlugin
                 if ($params->get('log_groups', 0)) {
                     Log::add(
                         new ExternalloginLogEntry(
-                            'Found integer group ' . $group . ' of groups for user "' . $response->username . '" on server ' . $sid,
+                            'Found integer group ' . $group . ' of groups for user "' . $extResponse->username . '" on server ' . $sid,
                             Log::INFO,
                             'system-caslogin-groups'
                         )
@@ -630,19 +638,19 @@ class Caslogin extends CMSPlugin
                     if ($params->get('log_groups', 0)) {
                         Log::add(
                             new ExternalloginLogEntry(
-                                'Added integer group ' . $group . ' of groups for user "' . $response->username . '" on server ' . $sid,
+                                'Added integer group ' . $group . ' of groups for user "' . $extResponse->username . '" on server ' . $sid,
                                 Log::INFO,
                                 'system-caslogin-groups'
                             )
                         );
                     }
-                    $response->groups[] = $group;
+                    $extResponse->groups[] = $group;
                 }
             } else {
                 if ($params->get('log_groups', 0)) {
                     Log::add(
                         new ExternalloginLogEntry(
-                            'Found string group(s) "' . $group . '" for user "' . $response->username . '" on server ' . $sid,
+                            'Found string group(s) "' . $group . '" for user "' . $extResponse->username . '" on server ' . $sid,
                             Log::INFO,
                             'system-caslogin-groups'
                         )
@@ -650,12 +658,12 @@ class Caslogin extends CMSPlugin
                 }
 
                 $newGroups = (array) ExternalloginHelper::getGroups($group, $params->get('group_separator', ''));
-                $response->groups = array_merge($response->groups, $newGroups);
+                $extResponse->groups = array_merge($extResponse->groups, $newGroups);
 
                 if ($params->get('log_groups', 0)) {
                     $message = empty($newGroups)
                         ? 'No Joomla! groups found from "' . $group . '" on server ' . $sid
-                        : 'Added groups (' . implode(',', $newGroups) . ') for user "' .  $response->username . '" on server ' . $sid;
+                        : 'Added groups (' . implode(',', $newGroups) . ') for user "' .  $extResponse->username . '" on server ' . $sid;
                     Log::add(
                         new ExternalloginLogEntry(
                             $message,
@@ -667,7 +675,7 @@ class Caslogin extends CMSPlugin
             }
         }
 
-        $event->setArgument('response', $response);
+        $event->setArgument('response', $extResponse);
 
         // Add result to the result array
         if ($event instanceof ResultAwareInterface) {

--- a/tests/Unit/Plugins/System/Caslogin/CasloginTest.php
+++ b/tests/Unit/Plugins/System/Caslogin/CasloginTest.php
@@ -6,6 +6,7 @@ use DOMDocument;
 use DOMXPath;
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Authentication\AuthenticationResponse;
+use Joomla\Component\Externallogin\Administrator\Authentication\ExternalAuthenticationResponse;
 use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
@@ -102,7 +103,7 @@ class CasloginTest extends TestCase
     public function testExtractsUsernameEmailAndFullnameFromTheCasResponse(): void
     {
         $plugin = $this->createPlugin(self::BASE_XML, self::BASE_PARAMS);
-        $response = new AuthenticationResponse();
+        $response = new ExternalAuthenticationResponse();
 
         $event = $this->dispatch($plugin, $response);
 
@@ -131,7 +132,7 @@ class CasloginTest extends TestCase
             XML;
 
         $plugin = $this->createPlugin($xml, self::BASE_PARAMS);
-        $response = new AuthenticationResponse();
+        $response = new ExternalAuthenticationResponse();
 
         $this->dispatch($plugin, $response);
 
@@ -143,7 +144,7 @@ class CasloginTest extends TestCase
     public function testGroupXpathEmptyLeavesGroupsUnset(): void
     {
         $plugin = $this->createPlugin(self::BASE_XML, self::BASE_PARAMS);
-        $response = new AuthenticationResponse();
+        $response = new ExternalAuthenticationResponse();
 
         $this->dispatch($plugin, $response);
 
@@ -154,7 +155,7 @@ class CasloginTest extends TestCase
     {
         $params = ['group_xpath' => 'cas:attributes/cas:role'] + self::BASE_PARAMS;
         $plugin = $this->createPlugin(self::BASE_XML, $params);
-        $response = new AuthenticationResponse();
+        $response = new ExternalAuthenticationResponse();
 
         $this->dispatch($plugin, $response);
 
@@ -180,7 +181,7 @@ class CasloginTest extends TestCase
             'group_separator' => '/',
         ] + self::BASE_PARAMS;
         $plugin = $this->createPlugin(self::BASE_XML, $params);
-        $response = new AuthenticationResponse();
+        $response = new ExternalAuthenticationResponse();
 
         $this->dispatch($plugin, $response);
 
@@ -209,7 +210,7 @@ class CasloginTest extends TestCase
 
         $params = ['group_xpath' => 'cas:attributes/cas:group', 'group_integer' => 1] + self::BASE_PARAMS;
         $plugin = $this->createPlugin(str_replace('Public/Editors', $group, self::BASE_XML), $params);
-        $response = new AuthenticationResponse();
+        $response = new ExternalAuthenticationResponse();
 
         $this->dispatch($plugin, $response);
 


### PR DESCRIPTION
## Description

Fixes PHP 8.2+ dynamic property deprecation warnings on `AuthenticationResponse` (`$server`, `$message`, `$groups`, `$subtype`).

Discovered during work on #229. Setting undeclared dynamic properties directly on Joomla core's `AuthenticationResponse` class emits deprecation notices in PHP 8.2+ and becomes a fatal error in future PHP versions.

## Summary of Changes

1. Introduced `ExternalAuthenticationResponse extends AuthenticationResponse` in `src/administrator/components/com_externallogin/src/Authentication/ExternalAuthenticationResponse.php` with declared public properties (`$server`, `$message`, `$groups`, `$subtype`) and a `fromResponse()` helper method.
2. Updated `Caslogin` and `Externallogin` plugins to use `ExternalAuthenticationResponse`.
3. Removed all dynamic property `@phpstan-ignore` annotations.
4. Updated unit tests in `CasloginTest`.

Closes #231