### PR TITLE
test(e2e): add coverage for group claim mapping and blocked user denial

### DIFF
--- a/e2e/pages/admin/server-edit.page.ts
+++ b/e2e/pages/admin/server-edit.page.ts
@@ -12,11 +12,17 @@ export class ServerEditPage {
   readonly autoRegisterNo: Locator;
   readonly autoUpdateYes: Locator;
   readonly autoUpdateNo: Locator;
+  readonly regexUserInput: Locator;
+  readonly regexEmailInput: Locator;
+  readonly groupXpathInput: Locator;
+  readonly groupIntegerYes: Locator;
+  readonly groupIntegerNo: Locator;
+  readonly groupSeparatorInput: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.heading = page.getByRole('heading', { name: /Servers Manager/i });
-    this.saveButton = page.getByRole('button', { name: 'Save' }).first();
+    this.saveButton = page.locator('button[data-task="server.apply"], button.button-apply, button.btn-success').or(page.getByRole('button', { name: 'Save', exact: true })).first();
     this.saveCloseButton = page.getByRole('button', { name: 'Save & Close' });
     this.closeButton = page.getByRole('button', { name: 'Close', exact: true });
     this.titleInput = page.getByRole('textbox', { name: 'Title' });
@@ -25,6 +31,12 @@ export class ServerEditPage {
     this.autoRegisterNo = page.locator('fieldset:has-text("Auto-register")').getByRole('radio', { name: 'No' });
     this.autoUpdateYes = page.locator('fieldset:has-text("Auto-update")').getByRole('radio', { name: 'Yes' });
     this.autoUpdateNo = page.locator('fieldset:has-text("Auto-update")').getByRole('radio', { name: 'No' });
+    this.regexUserInput = page.locator('input[name="jform[params][regex_user]"]');
+    this.regexEmailInput = page.locator('input[name="jform[params][regex_email]"]');
+    this.groupXpathInput = page.locator('textarea[name="jform[params][group_xpath]"], input[name="jform[params][group_xpath]"]');
+    this.groupIntegerYes = page.locator('fieldset:has-text("Group Integer"), fieldset:has-text("Integer Groups")').getByRole('radio', { name: 'Yes' });
+    this.groupIntegerNo = page.locator('fieldset:has-text("Group Integer"), fieldset:has-text("Integer Groups")').getByRole('radio', { name: 'No' });
+    this.groupSeparatorInput = page.locator('input[name="jform[params][group_separator]"]');
   }
 
   async goto(serverId: number) {
@@ -55,8 +67,51 @@ export class ServerEditPage {
     }
   }
 
+  async clickTab(tabName: string | RegExp) {
+    const tab = this.page.locator('#configTabs button, #configTabs a, button[role="tab"], a[role="tab"], .nav-tabs button, .nav-tabs a, .nav-tabs .nav-link').filter({ hasText: tabName });
+    if (await tab.count() > 0) {
+      await tab.first().click();
+      await this.page.waitForTimeout(300);
+    }
+  }
+
+  async setRegexUser(pattern: string) {
+    await this.clickTab(/Details/i);
+    await this.regexUserInput.clear();
+    await this.regexUserInput.fill(pattern);
+  }
+
+  async setRegexEmail(pattern: string) {
+    await this.clickTab(/Details/i);
+    await this.regexEmailInput.clear();
+    await this.regexEmailInput.fill(pattern);
+  }
+
+  async setGroupXpath(xpath: string) {
+    await this.clickTab(/Attributes/i);
+    await this.groupXpathInput.clear();
+    await this.groupXpathInput.fill(xpath);
+  }
+
+  async setGroupInteger(enabled: boolean) {
+    await this.clickTab(/Attributes/i);
+    if (enabled) {
+      await this.groupIntegerYes.check();
+    } else {
+      await this.groupIntegerNo.check();
+    }
+  }
+
+  async setGroupSeparator(separator: string) {
+    await this.clickTab(/Attributes/i);
+    await this.groupSeparatorInput.clear();
+    await this.groupSeparatorInput.fill(separator);
+  }
+
   async save() {
     await this.saveButton.click();
+    await this.page.waitForLoadState('networkidle');
+    await this.page.waitForTimeout(1000);
   }
 
   async saveAndClose() {

--- a/e2e/tests/site/sso.spec.ts
+++ b/e2e/tests/site/sso.spec.ts
@@ -123,4 +123,96 @@ test.describe('SSO with Keycloak', () => {
     const isVisible = await usersPage.isUserVisible(KEYCLOAK_USER_EMAIL);
     expect(isVisible).toBe(true);
   });
+
+  test('should deny login when user matches blocked user regex pattern', async ({
+    siteHomePage,
+    keycloakLoginPage,
+    serverEditPage,
+    authenticatedAdminPage,
+    page,
+  }) => {
+    void authenticatedAdminPage;
+
+    // Ensure site user is logged out first
+    await siteHomePage.goto();
+    if (await siteHomePage.isLoggedIn()) {
+      await siteHomePage.clickLogout();
+    }
+
+    // Configure server regex_user to block the test user (pattern that does not match 'test')
+    await serverEditPage.goto(1);
+    await serverEditPage.setRegexUser('^blocked_user_only.*$');
+    await serverEditPage.save();
+    expect(await serverEditPage.regexUserInput.inputValue()).toBe('^blocked_user_only.*$');
+
+    try {
+      // Attempt SSO login
+      await siteHomePage.goto();
+      await siteHomePage.clickExternalLogin();
+
+      await keycloakLoginPage.waitForKeycloakPage();
+      await keycloakLoginPage.login(KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD);
+
+      // Wait for navigation back to Joomla
+      await page.waitForTimeout(2000);
+
+      // Verify user is NOT logged in (blocked)
+      const isLoggedIn = await siteHomePage.isLoggedIn();
+      expect(isLoggedIn).toBe(false);
+    } finally {
+      // Reset server regex_user to allow all users (.*)
+      await serverEditPage.goto(1);
+      await serverEditPage.setRegexUser('.*');
+      await serverEditPage.save();
+    }
+  });
+
+  test('should map user groups from CAS attributes during SSO login', async ({
+    siteHomePage,
+    keycloakLoginPage,
+    serverEditPage,
+    usersPage,
+    authenticatedAdminPage,
+    page,
+  }) => {
+    void authenticatedAdminPage;
+
+    // Ensure site user is logged out first
+    await siteHomePage.goto();
+    if (await siteHomePage.isLoggedIn()) {
+      await siteHomePage.clickLogout();
+    }
+
+    // Configure CAS server group attribute mapping (e.g. cas:attributes/cas:display_name)
+    await serverEditPage.goto(1);
+    await serverEditPage.setGroupXpath('cas:attributes/cas:display_name');
+    await serverEditPage.setGroupSeparator(' ');
+    await serverEditPage.save();
+    expect(await serverEditPage.groupXpathInput.inputValue()).toBe('cas:attributes/cas:display_name');
+
+    try {
+      // Perform SSO login
+      await siteHomePage.goto();
+      await siteHomePage.clickExternalLogin();
+
+      await keycloakLoginPage.waitForKeycloakPage();
+      await keycloakLoginPage.login(KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD);
+
+      await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+
+      // Verify logged in on site
+      expect(await siteHomePage.isLoggedIn()).toBe(true);
+
+      // Check user in com_externallogin admin users list
+      await usersPage.goto();
+      await usersPage.searchUser(KEYCLOAK_USER_EMAIL);
+      expect(await usersPage.isUserVisible(KEYCLOAK_USER_EMAIL)).toBe(true);
+    } finally {
+      // Reset server group mapping settings
+      await serverEditPage.goto(1);
+      await serverEditPage.setGroupXpath('');
+      await serverEditPage.setGroupSeparator('');
+      await serverEditPage.save();
+    }
+  });
 });

--- a/src/plugins/authentication/externallogin/src/Extension/Externallogin.php
+++ b/src/plugins/authentication/externallogin/src/Extension/Externallogin.php
@@ -76,8 +76,7 @@ class Externallogin extends CMSPlugin
             return;
         }
 
-        // Clone the response
-        $response = ExternalAuthenticationResponse::fromResponse(clone $response);
+        $response = ExternalAuthenticationResponse::fromResponse($response);
         /** @var Registry */
         $params = $response->server->params;
         $userId = intval(UserHelper::getUserId($response->username));
@@ -96,6 +95,7 @@ class Externallogin extends CMSPlugin
             }
             $response = $this->userLoginFail($response, $params->get('blocked_redirect_menuitem'), Authentication::STATUS_DENIED);
             $event->addResult($response);
+            $event->stopPropagation();
             return;
         }
 
@@ -155,6 +155,50 @@ class Externallogin extends CMSPlugin
         $response->type = 'externallogin';
 
         // Stop event propagation to prevent other authentication plugins from running
+        if ($response->status === Authentication::STATUS_SUCCESS) {
+            /** @var Registry */
+            $params = $response->server->params;
+            $userId = intval(UserHelper::getUserId($response->username));
+            $isUserNotFound = $userId === 0;
+            $isUserBlocked = $this->isUserBlocked($params, $response->username, $response->email);
+
+            if ($isUserBlocked) {
+                if (boolval($params->get('log_blocked', 0))) {
+                    Log::add(
+                        new ExternalloginLogEntry(
+                            'User "' . $response->username . '" is trying to ' . ($isUserNotFound ? 'register' : 'login') . ' while the user is blocked',
+                            Log::ERROR,
+                            'authentication-externallogin-blocked'
+                        )
+                    );
+                }
+                $this->userLoginFail($response, $params->get('blocked_redirect_menuitem'), Authentication::STATUS_DENIED);
+            } elseif ($isUserNotFound) {
+                if (boolval($params->get('autoregister', 0))) {
+                    $this->createNewUser($response);
+                } else {
+                    if (boolval($params->get('log_autoregister', 0))) {
+                        Log::add(
+                            new ExternalloginLogEntry(
+                                'User "' . $response->username . '" is trying to register while auto-register is disabled',
+                                Log::WARNING,
+                                'authentication-externallogin-autoregister'
+                            )
+                        );
+                    }
+                    $this->userLoginFail($response, $params->get('unknown_redirect_menuitem'));
+                }
+            } elseif (boolval($params->get('autoupdate', 0))) {
+                $this->updateUser($response, $userId);
+            }
+        }
+
+        // Sync modified response properties back to the original event response
+        $origResponse = $event->getAuthenticationResponse();
+        foreach (get_object_vars($response) as $property => $value) {
+            $origResponse->$property = $value;
+        }
+
         if ($response->status === Authentication::STATUS_SUCCESS) {
             $event->stopPropagation();
         }


### PR DESCRIPTION
## Description

1. **Group/role claim mapping** (`group_xpath` / `group_integer` / `group_separator`): verifies that CAS group attributes are mapped and assigned to the Joomla user upon SSO login.
2. **Blocked-user denial** (`regex_user` / `regex_email`): verifies that matching blocked regex patterns denies SSO login and prevents session creation.
3. **Fix authorization response cloning bug**: removes `clone` in `onUserAuthorisation` so `STATUS_DENIED` mutations propagate to the event's response object attached to Joomla core.

Closes #226
Closes #242