### PR TITLE
fix(auth): stop propagation on any externallogin decision, not just success

### DIFF
--- a/.devcontainer/joomla/install.sh
+++ b/.devcontainer/joomla/install.sh
@@ -116,7 +116,9 @@ if dc_exec joomla test -f /var/www/html/cli/joomla.php; then
   dc_exec joomla php /var/www/html/cli/joomla.php cache:clean || true
 
   echo "Adding CAS Server definition ..."
-  CAS_PARAMS='{"autoregister":"1","autoupdate":"1","ssl":"1","url":"auth.dev.local","dir":"realms/demo/protocol/cas","cas_v3":"1","port":"443","username_xpath":"string(cas:attributes/cas:email)","name_xpath":"string(cas:attributes/cas:display_name)","email_xpath":"string(cas:attributes/cas:email)"}'
+  # autologout: log out of the Keycloak CAS session too, so it doesn't linger as a Keycloak SSO
+  # session that silently re-authenticates a later OIDC login attempt with the CAS identity (#249).
+  CAS_PARAMS='{"autoregister":"1","autoupdate":"1","autologout":"1","ssl":"1","url":"auth.dev.local","dir":"realms/demo/protocol/cas","cas_v3":"1","port":"443","username_xpath":"string(cas:attributes/cas:email)","name_xpath":"string(cas:attributes/cas:display_name)","email_xpath":"string(cas:attributes/cas:email)"}'
   joomla_mysql -e "INSERT IGNORE INTO ${JOOMLA_DB_PREFIX}externallogin_servers (title, published, plugin, ordering, params) VALUES ('Keycloak CAS', 1, 'system.caslogin', 1, '${CAS_PARAMS}');"
 
   echo "Adding OIDC Server definition ..."

--- a/e2e/tests/site/cross-protocol-login.spec.ts
+++ b/e2e/tests/site/cross-protocol-login.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD } from '../../fixtures/test-fixtures';
+
+const CAS_SERVER_TITLE = 'Keycloak CAS';
+const OIDC_SERVER_TITLE = 'Keycloak OIDC';
+
+test.describe('Cross-protocol Keycloak identity reuse', () => {
+  // Regression test for issue #249. CAS and OIDC servers backed by the same Keycloak realm share
+  // one Keycloak identity per user; logging in via both with the same identity (whether Keycloak's
+  // SSO session carries the identity over silently, or it's re-entered on a fresh Keycloak login
+  // form) makes the external-login bridge plugin (plugins/authentication/externallogin) deny the
+  // second attempt — the identity's email is already bound to the first server's account. Before
+  // the fix, that denial never stopped event propagation, so the core `authentication/joomla`
+  // plugin ran next and overwrote the response with its own generic "Empty password not allowed."
+  // message, masking the real reason.
+  test('OIDC login with an identity already bound to the CAS server must not surface the misleading core-Joomla error', async ({
+    siteHomePage,
+    keycloakLoginPage,
+    page,
+  }) => {
+    // Log in via CAS first so a Joomla account exists, bound to the CAS server, under the shared
+    // Keycloak identity.
+    await siteHomePage.goto();
+    await siteHomePage.clickExternalLogin(CAS_SERVER_TITLE);
+    await keycloakLoginPage.waitForKeycloakPage();
+    await keycloakLoginPage.login(KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD);
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    expect(await siteHomePage.isLoggedIn()).toBe(true);
+    await siteHomePage.clickLogout();
+
+    // Attempt an OIDC login with the same identity. Depending on whether the CAS server's
+    // "Automatic logout" setting terminated Keycloak's own SSO session, this either lands straight
+    // back on Joomla (silent SSO reuse) or shows a fresh Keycloak login form — handle both so the
+    // test reproduces the identity collision regardless of that setting.
+    await siteHomePage.goto();
+    await siteHomePage.clickExternalLogin(OIDC_SERVER_TITLE);
+    if (await keycloakLoginPage.usernameInput.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await keycloakLoginPage.login(KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD);
+    }
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+
+    // Whatever the specific outcome, the core Joomla plugin's generic empty-password fallback
+    // must never be what the visitor sees.
+    const bodyText = await page.textContent('body');
+    expect(bodyText).not.toMatch(/empty password not allowed/i);
+  });
+});

--- a/src/plugins/authentication/externallogin/src/Extension/Externallogin.php
+++ b/src/plugins/authentication/externallogin/src/Extension/Externallogin.php
@@ -142,9 +142,13 @@ class Externallogin extends CMSPlugin
             }
         }
 
-        if ($response->status === Authentication::STATUS_SUCCESS) {
-            $event->stopPropagation();
-        }
+        // A protocol plugin (caslogin/oidclogin) already made a definitive decision on this
+        // attempt — success or a specific denial (blocked/unknown-user/failed autoregister).
+        // Stop propagation regardless of outcome: CAS/OIDC logins never populate
+        // username/password, so leaving the event open lets a later core plugin (e.g.
+        // authentication/joomla) treat the empty credentials as its own failure and overwrite
+        // this response's status/error_message with a generic, misleading one (issue #249).
+        $event->stopPropagation();
     }
 
     /**

--- a/tests/Unit/Plugins/Authentication/Externallogin/ExternalloginTest.php
+++ b/tests/Unit/Plugins/Authentication/Externallogin/ExternalloginTest.php
@@ -150,6 +150,64 @@ class ExternalloginTest extends TestCase
             $event->getAuthenticationResponse()->status,
             'Blocked user must be denied on the true event subject, not just a disconnected local copy.'
         );
+        $this->assertTrue(
+            $event->isStopped(),
+            'A denied login is still a definitive decision by this plugin — propagation must stop so a later plugin (e.g. authentication/joomla) cannot overwrite it (issue #249).'
+        );
+    }
+
+    /**
+     * Reproduces issue #249: once the protocol plugin has made a decision on this login attempt
+     * (here, a denial because auto-register is disabled for an unknown user), a later
+     * authentication/joomla-like plugin — which always fails on the empty credentials CAS/OIDC
+     * logins submit — must never get a chance to run and clobber the specific denial reason with
+     * its own generic message.
+     */
+    public function testDeniedLoginStopsPropagationBeforeTheCoreJoomlaPluginCanOverwriteIt(): void
+    {
+        $server = (object) ['id' => 1, 'params' => new Registry([
+            'regex_user' => '.*',
+            'regex_email' => '.*',
+            'autoregister' => 0,
+        ])];
+        $this->bindDispatcherWithProtocolPlugin($server, 'dave', 'dave@example.com');
+
+        $database = $this->createMock(DatabaseInterface::class);
+        $database->method('getQuery')->willReturn($this->createMockQuery());
+        $database->method('createQuery')->willReturn($this->createMockQuery());
+        $database->method('loadResult')->willReturn(null); // unknown user
+        $this->bindDatabase($database);
+
+        $plugin = $this->createPlugin();
+
+        // Simulate the real onUserAuthenticate chain: externallogin (ordering 0) runs first,
+        // then a core-Joomla-like plugin (ordering 2) that always fails empty credentials and
+        // unconditionally overwrites the shared response, exactly like plugins/authentication/joomla.
+        $coreJoomlaLikePluginRan = false;
+        $chainDispatcher = new Dispatcher();
+        $chainDispatcher->addListener('onUserAuthenticate', [$plugin, 'onUserAuthenticate']);
+        $chainDispatcher->addListener('onUserAuthenticate', function (AuthenticationEvent $event) use (&$coreJoomlaLikePluginRan) {
+            $coreJoomlaLikePluginRan = true;
+            $response = $event->getAuthenticationResponse();
+            $response->status = Authentication::STATUS_FAILURE;
+            $response->error_message = 'Empty password not allowed.';
+        });
+
+        $subject = new AuthenticationResponse();
+        $event = new AuthenticationEvent('onUserAuthenticate', [
+            'credentials' => ['username' => '', 'password' => ''],
+            'options' => [],
+            'subject' => $subject,
+        ]);
+        $chainDispatcher->dispatch('onUserAuthenticate', $event);
+
+        $this->assertFalse(
+            $coreJoomlaLikePluginRan,
+            'Propagation must stop after externallogin denies the login, before a later core plugin can run.'
+        );
+        // userLoginFail()'s default status for an unknown user with auto-register disabled.
+        $this->assertSame(Authentication::STATUS_DENIED | Authentication::STATUS_UNKNOWN, $event->getAuthenticationResponse()->status);
+        $this->assertNotSame('Empty password not allowed.', $event->getAuthenticationResponse()->error_message);
     }
 
     public function testSuccessfulExistingUserLoginDoesNotAddDynamicPropertiesToTheSubject(): void


### PR DESCRIPTION
## Summary

- `Externallogin::onUserAuthenticate()` only called `$event->stopPropagation()` when the protocol plugin (caslogin/oidclogin) reported `STATUS_SUCCESS`. A denied outcome (blocked user, unknown user with auto-register disabled, failed auto-register/update) left the event open, so the core `authentication/joomla` plugin ran next, saw the always-empty username/password CAS/OIDC logins submit, and overwrote the response with its own generic "Empty password not allowed." message — masking the real reason.
- Fix: stop propagation whenever the bridge plugin has reached a definitive decision (the code path is only reachable once the protocol plugin actually engaged), not only on success.
- Complementary devcontainer change: seed the CAS server with `autologout=1` so logging out of Joomla also ends the Keycloak CAS session, instead of leaving a stale Keycloak SSO session that silently re-authenticates a later OIDC attempt with the CAS identity — the actual trigger observed while manually verifying #248.

## Test plan

- [x] `composer run lint` / `composer run phpstan` / `composer run test` (36 unit tests) all pass
- [x] New unit test `testDeniedLoginStopsPropagationBeforeTheCoreJoomlaPluginCanOverwriteIt` wires a real `Joomla\Event\Dispatcher` with the plugin followed by a fake core-Joomla-like listener, and asserts the core-like listener never runs and the denial's `error_message` survives
- [x] New e2e test `e2e/tests/site/cross-protocol-login.spec.ts`: CAS login → logout → OIDC login with the same Keycloak identity, asserting "Empty password not allowed." never appears; handles both the SSO-reuse and fresh-login-form branches (verified against the live devcontainer with `autologout` both off and on)
- [x] Full e2e suite (37 tests) and the `tests/site/` subset (15 tests, re-run after enabling `autologout=1` live) both pass — no regression to the existing CAS/OIDC suites
- [x] Two rounds of `/code-review` (Standards + Spec) — both clean; no findings required a code change

Closes #249