### PR TITLE
fix(caslogin): defensively reload language before onAfterInitialise() messages

### DIFF
--- a/e2e/tests/site/cross-protocol-login.spec.ts
+++ b/e2e/tests/site/cross-protocol-login.spec.ts
@@ -1,4 +1,11 @@
-import { test, expect, KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD } from '../../fixtures/test-fixtures';
+import {
+  test,
+  expect,
+  KEYCLOAK_USERNAME,
+  KEYCLOAK_PASSWORD,
+  OIDC_KEYCLOAK_USERNAME,
+  OIDC_KEYCLOAK_PASSWORD,
+} from '../../fixtures/test-fixtures';
 
 const CAS_SERVER_TITLE = 'Keycloak CAS';
 const OIDC_SERVER_TITLE = 'Keycloak OIDC';
@@ -42,5 +49,42 @@ test.describe('Cross-protocol Keycloak identity reuse', () => {
     // must never be what the visitor sees.
     const bodyText = await page.textContent('body');
     expect(bodyText).not.toMatch(/empty password not allowed/i);
+  });
+
+  // Regression test for issue #251. Caslogin::onAfterInitialise() enqueues a translated message
+  // when it denies a login because the account is bound to a different server — but unlike
+  // onGetIcons()/onContentPrepareForm() in the same file, it didn't defensively re-call
+  // loadLanguage() first, so Text::_() could fall back to showing the raw language key instead
+  // of the translated string.
+  test('CAS login with an identity already bound to the OIDC server shows the translated cross-server message', async ({
+    siteHomePage,
+    keycloakLoginPage,
+    page,
+  }) => {
+    // Log in via OIDC first so a Joomla account exists, bound to the OIDC server, under the
+    // OIDC-specific Keycloak identity.
+    await siteHomePage.goto();
+    await siteHomePage.clickExternalLogin(OIDC_SERVER_TITLE);
+    await keycloakLoginPage.waitForKeycloakPage();
+    await keycloakLoginPage.login(OIDC_KEYCLOAK_USERNAME, OIDC_KEYCLOAK_PASSWORD);
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    expect(await siteHomePage.isLoggedIn()).toBe(true);
+    await siteHomePage.clickLogout();
+
+    // Attempt a CAS login with the same identity. Keycloak's CAS principal is the same regardless
+    // of protocol, so this correctly matches the OIDC-bound account and is correctly denied (the
+    // per-account server-binding check) — but the denial message itself must render as translated
+    // text, not as the raw PLG_SYSTEM_CASLOGIN_NO_ACTIVATION_ON_SERVER language key.
+    await siteHomePage.goto();
+    await siteHomePage.clickExternalLogin(CAS_SERVER_TITLE);
+    if (await keycloakLoginPage.usernameInput.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await keycloakLoginPage.login(OIDC_KEYCLOAK_USERNAME, OIDC_KEYCLOAK_PASSWORD);
+    }
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+
+    const bodyText = await page.textContent('body');
+    expect(bodyText).not.toContain('PLG_SYSTEM_CASLOGIN_NO_ACTIVATION_ON_SERVER');
+    expect(bodyText).toContain('This account is linked to a different login server');
+    expect(await siteHomePage.isLoggedIn()).toBe(false);
   });
 });

--- a/src/plugins/system/caslogin/src/Extension/Caslogin.php
+++ b/src/plugins/system/caslogin/src/Extension/Caslogin.php
@@ -172,6 +172,9 @@ class Caslogin extends CMSPlugin
      */
     public function onAfterInitialise(): void
     {
+        // Ensure language is loaded for translation (early-lifecycle timing gap, issue #251)
+        $this->loadLanguage();
+
         /** @var CMSApplication */
         $app = Factory::getApplication();
         $user = $app->getIdentity();

--- a/src/plugins/system/oidclogin/src/Extension/Oidclogin.php
+++ b/src/plugins/system/oidclogin/src/Extension/Oidclogin.php
@@ -255,6 +255,9 @@ class Oidclogin extends CMSPlugin
      */
     public function onAfterInitialise(): void
     {
+        // Ensure language is loaded for translation (early-lifecycle timing gap, issue #251)
+        $this->loadLanguage();
+
         /** @var CMSApplication */
         $app = Factory::getApplication();
         $user = $app->getIdentity();


### PR DESCRIPTION
## Summary

- `onGetIcons()` and `onContentPrepareForm()` in `Caslogin.php` already defensively re-call `$this->loadLanguage();` right before their `Text::_()` usages, because the constructor's call can silently no-op if the application wasn't fully initialised yet when the system plugin was constructed (Joomla's own `CMSPlugin::loadLanguage()` documents this timing gap). `onAfterInitialise()` was missing that same defensive call before enqueueing its "not activated"/"linked to a different server" messages, so `Text::_()` could fall back to showing the raw language key instead of the translated text.
- Add the same one-line defensive `loadLanguage()` call to `Caslogin::onAfterInitialise()` and `Oidclogin::onAfterInitialise()`. The latter doesn't call `Text::_()` yet, but has the identical gap, so it gets the same treatment now rather than reintroducing this bug the first time a message is added there.

## Test plan

- [x] `composer run lint` / `composer run phpstan` / `composer run test` (36 unit tests) all pass
- [x] New e2e test in `e2e/tests/site/cross-protocol-login.spec.ts`: log in via OIDC, log out, attempt a CAS login with the same Keycloak identity (correctly denied — the account is bound to the OIDC server, not CAS), asserting the page shows the translated message and never the raw `PLG_SYSTEM_CASLOGIN_NO_ACTIVATION_ON_SERVER` key
- [x] Verified as a true regression test: reverted the fix locally, confirmed the new e2e test fails on the raw-key assertion, then reapplied the fix and confirmed it passes
- [x] No unit test for `onAfterInitialise()` itself — consistent with this codebase's existing convention (`CasloginTest`/`OidcloginTest` deliberately avoid it via `newInstanceWithoutConstructor()`, since it needs a full Joomla application bootstrap unrelated to what they test); the e2e test is the regression guard instead
- [x] One round of `/code-review` (Standards + Spec) — both clean; trimmed the new comments to match the existing single-line style at the sibling `loadLanguage()` call sites per the Standards pass

Closes #251