### PR TITLE
feat(oidc): implement RP-Initiated Logout for OIDC servers

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -57,8 +57,8 @@ docker compose -f compose.yml -f compose.debug.yml up -d
 ### Keycloak user
 
 - realm: `demo`
-- Username: `test` or `test-oidc`
-- Password: `test` or `test-oidc`
+- Username: `test` or `test2`
+- Password: `test` or `test2`
 
 ## Setup
 

--- a/.devcontainer/joomla/install.sh
+++ b/.devcontainer/joomla/install.sh
@@ -122,7 +122,10 @@ if dc_exec joomla test -f /var/www/html/cli/joomla.php; then
   joomla_mysql -e "INSERT IGNORE INTO ${JOOMLA_DB_PREFIX}externallogin_servers (title, published, plugin, ordering, params) VALUES ('Keycloak CAS', 1, 'system.caslogin', 1, '${CAS_PARAMS}');"
 
   echo "Adding OIDC Server definition ..."
-  OIDC_PARAMS='{"autoregister":"1","autoupdate":"1","issuer":"https://auth.dev.local/realms/demo","client_id":"joomla-oidc","client_secret":"dev-oidc-secret","username_claim":"preferred_username","name_claim":"name","email_claim":"email"}'
+  # autologout: end the Keycloak OIDC session too (RP-Initiated Logout), mirroring the CAS
+  # server's own autologout above (#249); post_logout_redirect sends the browser back to the
+  # site so e2e can assert on the resulting page after the round trip.
+  OIDC_PARAMS='{"autoregister":"1","autoupdate":"1","autologout":"1","post_logout_redirect":"https://www.dev.local/","issuer":"https://auth.dev.local/realms/demo","client_id":"joomla-oidc","client_secret":"dev-oidc-secret","username_claim":"preferred_username","name_claim":"name","email_claim":"email"}'
   joomla_mysql -e "INSERT IGNORE INTO ${JOOMLA_DB_PREFIX}externallogin_servers (title, published, plugin, ordering, params) VALUES ('Keycloak OIDC', 1, 'system.oidclogin', 2, '${OIDC_PARAMS}');"
 
   echo "Configuring External Login module ..."

--- a/.devcontainer/keycloak/import/demo-users-1.json
+++ b/.devcontainer/keycloak/import/demo-users-1.json
@@ -3,16 +3,16 @@
   "users" : [ {
     "id" : "d3f1d9a0-7b3e-4b3a-9e77-1a2b3c4d5e6f",
     "createdTimestamp" : 1696259429184,
-    "username" : "test-oidc",
+    "username" : "test2",
     "enabled" : true,
     "totp" : false,
     "emailVerified" : false,
-    "firstName" : "Oidc",
-    "lastName" : "Tester",
-    "email" : "test-oidc@example.com",
+    "firstName" : "Test",
+    "lastName" : "Two",
+    "email" : "test2@example.com",
     "credentials" : [ {
       "type" : "password",
-      "value" : "test-oidc",
+      "value" : "test2",
       "temporary" : false
     } ],
     "disableableCredentialTypes" : [ ],

--- a/e2e/fixtures/test-fixtures.ts
+++ b/e2e/fixtures/test-fixtures.ts
@@ -16,14 +16,13 @@ export const KEYCLOAK_USERNAME = 'test';
 export const KEYCLOAK_PASSWORD = 'test';
 export const KEYCLOAK_USER_EMAIL = 'test@example.com';
 export const KEYCLOAK_USER_DISPLAY_NAME = 'Foo Bar';
-// A separate Keycloak identity for the OIDC suite: it must not share the CAS
-// suite's KEYCLOAK_USERNAME identity, since CAS enforces its own "activated
-// for this server" binding once a Joomla account exists for a username —
-// which would otherwise reject the CAS suite's login after the OIDC suite
-// registers the same account against a different server.
-export const OIDC_KEYCLOAK_USERNAME = 'test-oidc';
-export const OIDC_KEYCLOAK_PASSWORD = 'test-oidc';
-export const OIDC_KEYCLOAK_USER_EMAIL = 'test-oidc@example.com';
+// A second Keycloak identity, not inherently tied to OIDC: the externallogin bridge plugin
+// binds a Joomla account to whichever server first logs it in, so reusing KEYCLOAK_USERNAME
+// here would make the OIDC suite's login attempt get rejected as "not activated for this
+// server" once the CAS suite has already registered that identity against the CAS server.
+export const OIDC_KEYCLOAK_USERNAME = 'test2';
+export const OIDC_KEYCLOAK_PASSWORD = 'test2';
+export const OIDC_KEYCLOAK_USER_EMAIL = 'test2@example.com';
 
 // Define fixture types
 type Fixtures = {

--- a/e2e/tests/site/oidc.spec.ts
+++ b/e2e/tests/site/oidc.spec.ts
@@ -62,7 +62,46 @@ test.describe('OIDC login with Keycloak', () => {
 
     await expect(siteHomePage.logoutButton).toBeVisible();
 
-    // Leave the site logged out for subsequent tests / suites.
+    // Leave the site logged out for subsequent tests / suites. The configured server has
+    // autologout enabled, so this chains into Keycloak's RP-Initiated Logout and lands back
+    // on the site via post_logout_redirect.
     await siteHomePage.clickLogout();
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+  });
+
+  test('should end the Keycloak session on logout when autologout is enabled (RP-Initiated Logout)', async ({
+    siteHomePage,
+    keycloakLoginPage,
+    page,
+  }) => {
+    await siteHomePage.goto();
+    await siteHomePage.clickExternalLogin(OIDC_SERVER_TITLE);
+
+    await keycloakLoginPage.waitForKeycloakPage();
+    await keycloakLoginPage.login(OIDC_KEYCLOAK_USERNAME, OIDC_KEYCLOAK_PASSWORD);
+
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    expect(await siteHomePage.isLoggedIn()).toBe(true);
+
+    // Logout triggers the plugin's RP-Initiated Logout redirect to Keycloak's
+    // end_session_endpoint with id_token_hint, which (with post_logout_redirect configured)
+    // sends the browser straight back to the site once Keycloak's own session is ended.
+    await siteHomePage.clickLogout();
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    await expect(siteHomePage.externalLoginButton).toBeVisible();
+
+    // Prove it was the *IdP* session that ended, not just the local Joomla one: if Keycloak's
+    // SSO session had survived, a fresh OIDC login attempt would silently re-authenticate
+    // without prompting for credentials. Requiring the login form again is the signal.
+    await siteHomePage.goto();
+    await siteHomePage.clickExternalLogin(OIDC_SERVER_TITLE);
+    await keycloakLoginPage.waitForKeycloakPage();
+    await expect(keycloakLoginPage.usernameInput).toBeVisible();
+
+    // Finish logging back in and log out again so subsequent tests / suites start fresh.
+    await keycloakLoginPage.login(OIDC_KEYCLOAK_USERNAME, OIDC_KEYCLOAK_PASSWORD);
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    await siteHomePage.clickLogout();
+    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
   });
 });

--- a/src/plugins/system/oidclogin/src/Extension/Oidclogin.php
+++ b/src/plugins/system/oidclogin/src/Extension/Oidclogin.php
@@ -31,6 +31,7 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Externallogin\Administrator\Authentication\ExternalAuthenticationResponse;
 use Joomla\Component\Externallogin\Administrator\Service\Logger\ExternalloginLogEntry;
 use Joomla\Component\Externallogin\Administrator\Table\ServerTable;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Event\Event;
 use Joomla\Http\HttpFactory;
@@ -71,6 +72,21 @@ class Oidclogin extends CMSPlugin
      * @var array<string, mixed>
      */
     protected array $claims = [];
+
+    /**
+     * The externallogin server row bound to the user being logged out, captured by
+     * onUserLogout (before Joomla destroys the session) for onUserAfterLogout to redirect with,
+     * once the local session is already gone.
+     *
+     * @var object|null
+     */
+    protected $logoutServer;
+
+    /**
+     * The id_token retained from the user's OIDC login, captured by onUserLogout from session
+     * state before Joomla's own onUserLogout listener destroys it.
+     */
+    protected ?string $logoutIdToken = null;
 
     /**
      * Constructor.
@@ -361,6 +377,10 @@ class Oidclogin extends CMSPlugin
         $this->claims = array_merge($idTokenClaims, $userInfoClaims);
         $this->server = $server;
 
+        // Retained for RP-Initiated Logout's id_token_hint. Must be read back from session state
+        // during onUserLogout, before Joomla's own onUserLogout listener destroys the session.
+        $app->setUserState('system.oidclogin.idtoken.' . $serverID, (string) $tokens['id_token']);
+
         $service = Uri::getInstance();
 
         foreach (['code', 'state', 'error', 'error_description', 'session_state', 'iss'] as $var) {
@@ -476,6 +496,120 @@ class Oidclogin extends CMSPlugin
             $results[] = true;
             $event->setArgument('result', $results);
         }
+    }
+
+    /**
+     * User logout event.
+     *
+     * Captures the externallogin server and retained id_token for the user being logged out,
+     * while the session (and thus the id_token stored in it) is still intact — Joomla's own
+     * onUserLogout listener destroys the session immediately after this event, before
+     * onUserAfterLogout fires.
+     *
+     * @param array{id: int, username: string} $user
+     * @param array<string, mixed> $options
+     *
+     * @return bool
+     */
+    public function onUserLogout($user, $options = [])
+    {
+        /** @var CMSApplication */
+        $app = Factory::getApplication();
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
+        $query = $db->getQuery(true);
+        $query->select('a.*')
+            ->from('#__externallogin_servers AS a')
+            ->leftJoin('#__externallogin_users AS e ON e.server_id = a.id')
+            ->where('a.plugin = ' . $db->quote('system.oidclogin'))
+            ->where('e.user_id = ' . (int) $user['id']);
+        $db->setQuery($query);
+        $server = $db->loadObject();
+
+        if (is_null($server)) {
+            return true;
+        }
+
+        $params = new Registry($server->params);
+
+        if (!boolval($params->get('autologout'))) {
+            return true;
+        }
+
+        $idToken = $app->getUserState('system.oidclogin.idtoken.' . $server->id);
+
+        if (!is_string($idToken) || $idToken === '') {
+            return true;
+        }
+
+        $this->logoutServer = $server;
+        $this->logoutIdToken = $idToken;
+
+        return true;
+    }
+
+    /**
+     * Redirect to the OIDC end_session_endpoint (RP-Initiated Logout) when a user logs out.
+     *
+     * Degrades to a local-only Joomla logout — never a hard failure — when autologout is off,
+     * no id_token was captured, or the IdP's discovery document has no end_session_endpoint.
+     */
+    public function onUserAfterLogout($options)
+    {
+        /** @var CMSApplication */
+        $app = Factory::getApplication();
+        $local = $app->getInput()->get('local');
+
+        if (isset($local) || $this->logoutServer === null || $this->logoutIdToken === null) {
+            return true;
+        }
+
+        $server = $this->logoutServer;
+        $params = new Registry($server->params);
+
+        $this->log(
+            $params,
+            'log_logout',
+            'system-oidclogin-logout',
+            'Logout of user "' . $options['username'] . '" on server ' . $server->id,
+            Log::INFO
+        );
+
+        // A null discovery document means the fetch itself failed; getDiscoveryDocument() has
+        // already logged that unconditionally, so don't log a second, misleading message here.
+        $discovery = $this->getDiscoveryDocument($params, $server->id);
+
+        if ($discovery === null) {
+            return true;
+        }
+
+        if (empty($discovery['end_session_endpoint'])) {
+            $this->log(
+                $params,
+                'log_logout',
+                'system-oidclogin-logout',
+                'No end_session_endpoint in discovery document on server ' . $server->id . ', falling back to local-only logout',
+                Log::WARNING
+            );
+
+            return true;
+        }
+
+        $query = [
+            'id_token_hint' => $this->logoutIdToken,
+        ];
+
+        $postLogoutRedirect = $params->get('post_logout_redirect');
+
+        if (!empty($postLogoutRedirect)) {
+            $query['post_logout_redirect_uri'] = $postLogoutRedirect;
+        }
+
+        $separator = str_contains((string) $discovery['end_session_endpoint'], '?') ? '&' : '?';
+        $redirect = $discovery['end_session_endpoint'] . $separator . http_build_query($query);
+
+        $app->redirect($redirect, 302);
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add RP-Initiated Logout to `system.oidclogin`: when a server's `autologout` toggle is enabled, Joomla logout redirects to the IdP's discovered `end_session_endpoint` with `id_token_hint` (retained from the login session) and `post_logout_redirect_uri` when `post_logout_redirect` is configured, mirroring `Caslogin`'s existing `autologout` behavior.
- Degrades gracefully to a local-only Joomla logout — never a hard failure — when `autologout` is off, no `id_token` was captured, or the IdP's discovery document has no `end_session_endpoint`.
- `log_logout` independently gates logout-event logging, mirroring CAS's own toggle.
- The `id_token` is captured from session state during `onUserLogout` (before Joomla's own listener destroys the session) and consumed in `onUserAfterLogout` (after it's destroyed), matching where `Caslogin` performs its own logout redirect.
- Enables `autologout` + `post_logout_redirect` on the devcontainer's Keycloak OIDC server and extends e2e with a full login → logout round trip that verifies the Keycloak IdP session itself ended (not just the local Joomla session).

Closes #240

## Test plan
- [x] `composer run lint` — clean
- [x] `composer run phpstan` — no errors
- [x] Two rounds of `/code-review` (Standards + Spec) — round 2 clean on both axes
- [x] e2e: full OIDC suite (6 tests) passes against the live devcontainer stack, including the new logout round-trip test
- [x] e2e: full regression suite (38 tests: admin, SSO/CAS, cross-protocol, OIDC) passes with no breakage