### PR TITLE
feat(oidc): implement OIDC autologin

### DIFF
--- a/.devcontainer/AGENTS.md
+++ b/.devcontainer/AGENTS.md
@@ -56,7 +56,17 @@ Skip full reinstall; copy then clear cache:
 docker compose -f .devcontainer/compose.yml cp src/plugins/system/caslogin/src/Extension/Caslogin.php joomla:/var/www/html/plugins/system/caslogin/src/Extension/Caslogin.php
 docker compose -f .devcontainer/compose.yml cp src/plugins/system/caslogin/language joomla:/var/www/html/plugins/system/caslogin/
 docker compose -f .devcontainer/compose.yml cp src/administrator/components/com_externallogin/tmpl/servers/default.php joomla:/var/www/html/administrator/components/com_externallogin/tmpl/servers/default.php
-docker compose -f .devcontainer/compose.yml exec joomla php /var/www/html/cli/joomla.php cache:clean
+# Always clear cache as www-data. Root CLI rewrites administrator/cache/language
+# as root-owned; Apache then hits Permission denied and can 500 the admin UI
+# (language-load recursion).
+docker compose -f .devcontainer/compose.yml exec -u www-data joomla php /var/www/html/cli/joomla.php cache:clean
+```
+
+If you already ran CLI or `compose cp` as root and admin returns HTTP 500:
+
+```sh
+docker compose -f .devcontainer/compose.yml exec joomla \
+  chown -R www-data:www-data /var/www/html/administrator/cache /var/www/html/cache /var/www/html/tmp
 ```
 
 ## Diagnosing Issues
@@ -68,3 +78,5 @@ tail -20 /www/html/administrator/logs/everything.php
 # Container logs
 docker compose -f .devcontainer/compose.yml logs --tail 100 joomla
 ```
+
+**Admin HTTP 500 after file-copy / cache:clean:** check ownership first — `ls -la /var/www/html/administrator/cache/language` owned by `root` (with Apache as `www-data`) matches this failure mode. Container logs often show `file_put_contents(.../cache/language...): Permission denied` and a deep `Language::load` stack. Fix with the `chown` above, then re-test `/administrator/`.

--- a/e2e/pages/admin/server-edit.page.ts
+++ b/e2e/pages/admin/server-edit.page.ts
@@ -19,6 +19,8 @@ export class ServerEditPage {
   readonly groupIntegerYes: Locator;
   readonly groupIntegerNo: Locator;
   readonly groupSeparatorInput: Locator;
+  readonly autologinYes: Locator;
+  readonly autologinNo: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -39,6 +41,10 @@ export class ServerEditPage {
     this.groupIntegerYes = page.locator('fieldset:has-text("Group Integer"), fieldset:has-text("Integer Groups")').getByRole('radio', { name: 'Yes' });
     this.groupIntegerNo = page.locator('fieldset:has-text("Group Integer"), fieldset:has-text("Integer Groups")').getByRole('radio', { name: 'No' });
     this.groupSeparatorInput = page.locator('input[name="jform[params][group_separator]"]');
+    // Connection-tab "Automatic login" (autologin) radios — match by the param name so
+    // we don't confuse them with the similarly labelled "Automatic logout" radios.
+    this.autologinYes = page.locator('input[name="jform[params][autologin]"][value="1"]');
+    this.autologinNo = page.locator('input[name="jform[params][autologin]"][value="0"]');
   }
 
   async goto(serverId: number) {
@@ -114,6 +120,15 @@ export class ServerEditPage {
     await this.clickTab(/Attributes/i);
     await this.groupSeparatorInput.clear();
     await this.groupSeparatorInput.fill(separator);
+  }
+
+  async setAutologin(enabled: boolean) {
+    await this.clickTab(/Connection/i);
+    if (enabled) {
+      await this.autologinYes.check({ force: true });
+    } else {
+      await this.autologinNo.check({ force: true });
+    }
   }
 
   async save() {

--- a/e2e/pages/keycloak/login.page.ts
+++ b/e2e/pages/keycloak/login.page.ts
@@ -1,5 +1,8 @@
 import { type Page, type Locator } from '@playwright/test';
 
+/** Site host after IdP redirects back (query/path may vary). */
+const SITE_URL = /^https:\/\/www\.dev\.local/;
+
 export class KeycloakLoginPage {
   readonly page: Page;
   readonly usernameInput: Locator;
@@ -16,9 +19,48 @@ export class KeycloakLoginPage {
   }
 
   async login(username: string, password: string) {
+    await this.usernameInput.waitFor({ state: 'visible', timeout: 30000 });
     await this.usernameInput.fill(username);
     await this.passwordInput.fill(password);
     await this.loginButton.click();
+  }
+
+  /**
+   * After the site starts an IdP login, either:
+   * - Keycloak shows a credential form (no IdP session), or
+   * - the browser returns to the site (existing IdP SSO / silent reuse).
+   *
+   * Prefer this over a fixed isVisible timeout: polling form-vs-return avoids
+   * the flaky path where the form is still loading when a short timeout fires
+   * and the test then waitForURL's the site while still stuck on Keycloak.
+   * (A Promise.race of two waits would leave the loser as an unhandled reject.)
+   */
+  async completeLoginIfPrompted(
+    username: string,
+    password: string,
+    options: { timeout?: number } = {},
+  ) {
+    const timeout = options.timeout ?? 30000;
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      if (SITE_URL.test(this.page.url())) {
+        return;
+      }
+
+      if (await this.usernameInput.isVisible().catch(() => false)) {
+        await this.login(username, password);
+        const remaining = Math.max(10_000, deadline - Date.now());
+        await this.page.waitForURL(SITE_URL, { timeout: remaining });
+        return;
+      }
+
+      await this.page.waitForTimeout(200);
+    }
+
+    throw new Error(
+      `Timed out after ${timeout}ms waiting for Keycloak login form or redirect back to site (url=${this.page.url()})`,
+    );
   }
 
   async isOnKeycloakPage(): Promise<boolean> {

--- a/e2e/pages/site/home.page.ts
+++ b/e2e/pages/site/home.page.ts
@@ -50,6 +50,16 @@ export class SiteHomePage {
     await this.logoutButton.click();
   }
 
+  /**
+   * Logout and wait until the External Login module shows Log in again.
+   * OIDC servers with autologout may bounce through the IdP before returning.
+   */
+  async logoutAndWaitForGuest(timeout = 15000) {
+    await this.clickLogout();
+    await this.page.waitForURL(/^https:\/\/www\.dev\.local/, { timeout });
+    await this.externalLoginButton.waitFor({ state: 'visible', timeout });
+  }
+
   async isLoggedIn(): Promise<boolean> {
     return this.logoutButton.isVisible({ timeout: 5000 }).catch(() => false);
   }

--- a/e2e/tests/site/cross-protocol-login.spec.ts
+++ b/e2e/tests/site/cross-protocol-login.spec.ts
@@ -34,9 +34,9 @@ test.describe('Cross-protocol Keycloak identity reuse', () => {
     await siteHomePage.clickExternalLogin(CAS_SERVER_TITLE);
     await keycloakLoginPage.waitForKeycloakPage();
     await keycloakLoginPage.login(KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD);
-    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    await page.waitForURL(/^https:\/\/www\.dev\.local/, { timeout: 30000 });
     expect(await siteHomePage.isLoggedIn()).toBe(true);
-    await siteHomePage.clickLogout();
+    await siteHomePage.logoutAndWaitForGuest();
 
     // Attempt an OIDC login with the same identity. Depending on whether the CAS server's
     // "Automatic logout" setting terminated Keycloak's own SSO session, this either lands straight
@@ -44,10 +44,7 @@ test.describe('Cross-protocol Keycloak identity reuse', () => {
     // test reproduces the identity collision regardless of that setting.
     await siteHomePage.goto();
     await siteHomePage.clickExternalLogin(OIDC_SERVER_TITLE);
-    if (await keycloakLoginPage.usernameInput.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await keycloakLoginPage.login(KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD);
-    }
-    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    await keycloakLoginPage.completeLoginIfPrompted(KEYCLOAK_USERNAME, KEYCLOAK_PASSWORD);
 
     const bodyText = await page.textContent('body');
     // The core Joomla plugin's generic empty-password fallback must never be what the visitor sees.
@@ -74,9 +71,10 @@ test.describe('Cross-protocol Keycloak identity reuse', () => {
     await siteHomePage.clickExternalLogin(OIDC_SERVER_TITLE);
     await keycloakLoginPage.waitForKeycloakPage();
     await keycloakLoginPage.login(OIDC_KEYCLOAK_USERNAME, OIDC_KEYCLOAK_PASSWORD);
-    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    await page.waitForURL(/^https:\/\/www\.dev\.local/, { timeout: 30000 });
     expect(await siteHomePage.isLoggedIn()).toBe(true);
-    await siteHomePage.clickLogout();
+    // OIDC fixture has autologout on — logout may round-trip through Keycloak.
+    await siteHomePage.logoutAndWaitForGuest();
 
     // Attempt a CAS login with the same identity. Keycloak's CAS principal is the same regardless
     // of protocol, so this correctly matches the OIDC-bound account and is correctly denied (the
@@ -84,10 +82,7 @@ test.describe('Cross-protocol Keycloak identity reuse', () => {
     // text, not as a raw language key.
     await siteHomePage.goto();
     await siteHomePage.clickExternalLogin(CAS_SERVER_TITLE);
-    if (await keycloakLoginPage.usernameInput.isVisible({ timeout: 5000 }).catch(() => false)) {
-      await keycloakLoginPage.login(OIDC_KEYCLOAK_USERNAME, OIDC_KEYCLOAK_PASSWORD);
-    }
-    await page.waitForURL(/^https:\/\/www\.dev\.local\/?/, { timeout: 15000 });
+    await keycloakLoginPage.completeLoginIfPrompted(OIDC_KEYCLOAK_USERNAME, OIDC_KEYCLOAK_PASSWORD);
 
     const bodyText = await page.textContent('body');
     expect(bodyText).not.toContain('PLG_SYSTEM_CASLOGIN_NO_ACTIVATION_ON_SERVER');

--- a/e2e/tests/site/oidc.spec.ts
+++ b/e2e/tests/site/oidc.spec.ts
@@ -175,4 +175,81 @@ test.describe('OIDC login with Keycloak', () => {
       await serverEditPage.save();
     }
   });
+
+  test('should redirect guest to IdP when OIDC autologin is enabled', async ({
+    siteHomePage,
+    serverEditPage,
+    authenticatedAdminPage,
+    page,
+    browser,
+  }) => {
+    void authenticatedAdminPage;
+    void siteHomePage;
+
+    // Enable autologin on the OIDC server (default off in the install fixture).
+    // Done on the admin-authenticated fixture page so we can tear it down afterwards.
+    await serverEditPage.goto(OIDC_SERVER_ID);
+    await serverEditPage.setAutologin(true);
+    await serverEditPage.save();
+
+    // Isolated guest context: earlier tests in this file leave residual
+    // com_externallogin.server / oidclogin session state that would short-circuit
+    // the autologin branch once a server is already selected for the session.
+    const guestContext = await browser.newContext({ ignoreHTTPSErrors: true });
+    const guestPage = await guestContext.newPage();
+
+    try {
+      // Fresh guest visit — no login-button click. Autologin uses prompt=none
+      // (OIDC silent authentication), so the browser is redirected to Keycloak's
+      // authorization endpoint. Capture that request to prove the redirect fired
+      // without the user clicking the External Login module button.
+      const authRequestPromise = guestPage.waitForRequest(
+        (request) =>
+          request.url().includes('auth.dev.local') &&
+          request.url().includes('/protocol/openid-connect/auth') &&
+          request.url().includes('prompt=none'),
+        { timeout: 15000 },
+      );
+
+      await guestPage.goto('https://www.dev.local/', { waitUntil: 'commit' });
+      const authRequest = await authRequestPromise;
+      expect(authRequest.url()).toContain('client_id=joomla-oidc');
+
+      // Without an existing IdP session, prompt=none bounces back with
+      // error=login_required. The visitor remains a guest, and the once-per-session
+      // guard prevents a redirect loop.
+      await guestPage.waitForURL(/^https:\/\/www\.dev\.local/, { timeout: 15000 });
+      const logoutVisible = await guestPage
+        .locator('.externallogin input[type="submit"], .externallogin button')
+        .filter({ hasText: /Log out/i })
+        .first()
+        .isVisible({ timeout: 3000 })
+        .catch(() => false);
+      expect(logoutVisible).toBe(false);
+
+      // Second visit in the same session must not re-hit the IdP authorization endpoint.
+      let secondAuthHit = false;
+      const secondAuthListener = (request: { url: () => string }) => {
+        if (
+          request.url().includes('auth.dev.local') &&
+          request.url().includes('/protocol/openid-connect/auth')
+        ) {
+          secondAuthHit = true;
+        }
+      };
+      guestPage.on('request', secondAuthListener);
+      try {
+        await guestPage.goto('https://www.dev.local/', { waitUntil: 'domcontentloaded' });
+        await guestPage.waitForTimeout(2000);
+      } finally {
+        guestPage.off('request', secondAuthListener);
+      }
+      expect(secondAuthHit).toBe(false);
+    } finally {
+      await guestContext.close();
+      await serverEditPage.goto(OIDC_SERVER_ID);
+      await serverEditPage.setAutologin(false);
+      await serverEditPage.save();
+    }
+  });
 });

--- a/src/plugins/system/oidclogin/src/Extension/Oidclogin.php
+++ b/src/plugins/system/oidclogin/src/Extension/Oidclogin.php
@@ -30,6 +30,7 @@ use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Externallogin\Administrator\Authentication\ExternalAuthenticationResponse;
 use Joomla\Component\Externallogin\Administrator\Helper\ExternalloginHelper;
+use Joomla\Component\Externallogin\Administrator\Model\ServersModel;
 use Joomla\Component\Externallogin\Administrator\Service\Logger\ExternalloginLogEntry;
 use Joomla\Component\Externallogin\Administrator\Table\ServerTable;
 use Joomla\Database\DatabaseInterface;
@@ -197,7 +198,7 @@ class Oidclogin extends CMSPlugin
      * Redirects to the IdP's discovered authorization_endpoint using
      * Authorization Code Flow with PKCE. The state/nonce/code_verifier for
      * this attempt are stored in the Joomla session (user state), not the
-     * database, mirroring how Caslogin stores its own per-attempt state.
+     * database — they are one-time values for the return leg only.
      */
     public function onGetLoginUrl(Event $event): void
     {
@@ -209,48 +210,17 @@ class Oidclogin extends CMSPlugin
 
         /** @var Registry $params */
         $params = $server->params;
-        $discovery = $this->getDiscoveryDocument($params, $server->id);
-
-        if ($discovery === null || empty($discovery['authorization_endpoint'])) {
-            return;
-        }
-
         $service = $event->getArgument('service');
 
         if ($service instanceof Uri) {
             $service = (string) $service;
         }
 
-        $state = bin2hex(random_bytes(16));
-        $nonce = bin2hex(random_bytes(16));
-        $verifier = $this->base64UrlEncode(random_bytes(32));
-        $challenge = $this->base64UrlEncode(hash('sha256', $verifier, true));
+        $url = $this->buildAuthorizationUrl($params, $server->id, (string) $service);
 
-        /** @var CMSApplication */
-        $app = Factory::getApplication();
-        $app->setUserState('system.oidclogin.state.' . $server->id, $state);
-        $app->setUserState('system.oidclogin.nonce.' . $server->id, $nonce);
-        $app->setUserState('system.oidclogin.verifier.' . $server->id, $verifier);
-        $app->setUserState('system.oidclogin.redirect.' . $server->id, $service);
-
-        $query = [
-            'response_type' => 'code',
-            'client_id' => (string) $params->get('client_id'),
-            'redirect_uri' => $service,
-            'scope' => 'openid profile email',
-            'state' => $state,
-            'nonce' => $nonce,
-            'code_challenge' => $challenge,
-            'code_challenge_method' => 'S256',
-        ];
-
-        if ($params->get('locale')) {
-            [$locale] = explode('-', Factory::getApplication()->getLanguage()->getTag());
-            $query['ui_locales'] = $locale;
+        if ($url === null) {
+            return;
         }
-
-        $separator = str_contains((string) $discovery['authorization_endpoint'], '?') ? '&' : '?';
-        $url = $discovery['authorization_endpoint'] . $separator . http_build_query($query);
 
         $this->log($params, 'log_login', 'system-oidclogin-login', 'Redirecting to authorization endpoint on server ' . $server->id, Log::INFO);
 
@@ -264,11 +234,12 @@ class Oidclogin extends CMSPlugin
     /**
      * After initialise event.
      *
-     * Detects the return leg of an authorization-code login attempt this
-     * plugin itself initiated (a "code"/"state"/"error" query parameter),
-     * exchanges the code for tokens, verifies the ID Token, merges in
-     * UserInfo claims, and rewires the request so Joomla's own login
-     * machinery picks it up — mirroring Caslogin::onAfterInitialise().
+     * 1. Autologin — when a guest has no OIDC callback in flight, redirect once
+     *    per session to a published, autologin-enabled OIDC server using
+     *    prompt=none (OIDC silent authentication).
+     * 2. Callback — when the IdP returns a code/error, exchange the code for
+     *    tokens, verify the ID Token, merge UserInfo claims, and rewire the
+     *    request so Joomla's own login machinery picks it up.
      */
     public function onAfterInitialise(): void
     {
@@ -287,20 +258,106 @@ class Oidclogin extends CMSPlugin
         $code = $input->get('code', '', 'RAW');
         $state = $input->get('state', '', 'RAW');
         $error = $input->get('error', '', 'RAW');
+        $serverID = $app->isClient('administrator') ? $input->get('server') : $app->getUserState('com_externallogin.server');
+        /** @var MVCFactoryServiceInterface */
+        $component = $app->bootComponent('com_externallogin');
+        $mvcFactory = $component->getMVCFactory();
 
+        // No OIDC callback in flight — try autologin (once per session per server).
         if (!$code && !$error) {
+            if (!$serverID) {
+                /** @var ServersModel $model */
+                $model = $mvcFactory->createModel('Servers', 'Administrator', ['ignore_request' => true]);
+
+                if (!$model) {
+                    return;
+                }
+
+                $model->setState('filter.published', 1);
+                $model->setState('filter.plugin', 'system.oidclogin');
+                $model->setState('list.start', 0);
+                $model->setState('list.limit', 0);
+                $model->setState('list.ordering', 'a.ordering');
+                $model->setState('list.direction', 'ASC');
+                $servers = $model->getItems();
+
+                foreach ($servers as $server) {
+                    $params = new Registry($server->params);
+                    $serverID = $server->id;
+
+                    if (boolval($params->get('autologin')) && !$app->getUserState('system.oidclogin.autologin.' . $server->id)) {
+                        if (!$this->verifyServerIsAlive($params)) {
+                            $this->log(
+                                $params,
+                                'log_verify',
+                                'system-oidclogin-verify',
+                                'Unsuccessful verification of server ' . $serverID,
+                                Log::WARNING
+                            );
+
+                            continue;
+                        }
+
+                        $this->log(
+                            $params,
+                            'log_verify',
+                            'system-oidclogin-verify',
+                            'Successful verification of server ' . $serverID,
+                            Log::INFO
+                        );
+
+                        $service = (string) Uri::getInstance();
+                        // prompt=none: silent auth when the IdP already has a session; otherwise
+                        // the IdP returns error=login_required and we do not retry this session.
+                        $url = $this->buildAuthorizationUrl($params, $server->id, $service, true);
+
+                        if ($url === null) {
+                            continue;
+                        }
+
+                        $this->log(
+                            $params,
+                            'log_autologin',
+                            'system-oidclogin-autologin',
+                            'Trying autologin on server ' . $serverID,
+                            Log::INFO
+                        );
+
+                        $app->setUserState('com_externallogin.server', $server->id);
+                        $app->setUserState('system.oidclogin.autologin.' . $server->id, 1);
+                        $app->redirect($url, 302);
+
+                        break;
+                    }
+                }
+
+                return;
+            }
+
+            // serverID is set but no callback arrived — the visitor cancelled, the IdP was
+            // unreachable after the probe, or a prior attempt left residual state. Log when
+            // log_autologin is on (can fire on every subsequent guest request with residual
+            // com_externallogin.server until the session ends).
+            /** @var ServerTable|bool $server */
+            $server = $mvcFactory->createTable('Server', 'Administrator');
+
+            if ($server && $server->load($serverID) && $server->plugin == 'system.oidclogin') {
+                $this->log(
+                    $server->params,
+                    'log_autologin',
+                    'system-oidclogin-autologin',
+                    'Autologin failed on server ' . $serverID,
+                    Log::INFO
+                );
+            }
+
             return;
         }
-
-        $serverID = $app->isClient('administrator') ? $input->get('server') : $app->getUserState('com_externallogin.server');
 
         if (!$serverID) {
             return;
         }
 
-        /** @var MVCFactoryServiceInterface */
-        $component = $app->bootComponent('com_externallogin');
-        $mvcFactory = $component->getMVCFactory();
         /** @var ServerTable|bool $server */
         $server = $mvcFactory->createTable('Server', 'Administrator');
 
@@ -322,6 +379,17 @@ class Oidclogin extends CMSPlugin
         $app->setUserState('system.oidclogin.redirect.' . $serverID, null);
 
         if ($error || !$code || !$state || !is_string($expectedState) || !hash_equals($expectedState, (string) $state)) {
+            // prompt=none autologin failures surface as error=login_required (or interaction_required).
+            if ($error && $app->getUserState('system.oidclogin.autologin.' . $serverID)) {
+                $this->log(
+                    $params,
+                    'log_autologin',
+                    'system-oidclogin-autologin',
+                    'Autologin failed on server ' . $serverID . ': ' . $error,
+                    Log::INFO
+                );
+            }
+
             $this->log(
                 $params,
                 'log_login',
@@ -736,6 +804,110 @@ class Oidclogin extends CMSPlugin
     }
 
     /**
+     * Build the IdP authorization URL (Authorization Code + PKCE), storing
+     * state/nonce/verifier/redirect_uri in the session for the return leg.
+     *
+     * @param Registry $params
+     * @param int|string $serverID
+     * @param bool $promptNone when true, set prompt=none for OIDC silent authentication
+     */
+    private function buildAuthorizationUrl($params, $serverID, string $redirectUri, bool $promptNone = false): ?string
+    {
+        $discovery = $this->getDiscoveryDocument($params, $serverID);
+
+        if ($discovery === null || empty($discovery['authorization_endpoint'])) {
+            return null;
+        }
+
+        $state = bin2hex(random_bytes(16));
+        $nonce = bin2hex(random_bytes(16));
+        $verifier = $this->base64UrlEncode(random_bytes(32));
+        $challenge = $this->base64UrlEncode(hash('sha256', $verifier, true));
+
+        /** @var CMSApplication */
+        $app = Factory::getApplication();
+        $app->setUserState('system.oidclogin.state.' . $serverID, $state);
+        $app->setUserState('system.oidclogin.nonce.' . $serverID, $nonce);
+        $app->setUserState('system.oidclogin.verifier.' . $serverID, $verifier);
+        $app->setUserState('system.oidclogin.redirect.' . $serverID, $redirectUri);
+
+        $query = [
+            'response_type' => 'code',
+            'client_id' => (string) $params->get('client_id'),
+            'redirect_uri' => $redirectUri,
+            'scope' => 'openid profile email',
+            'state' => $state,
+            'nonce' => $nonce,
+            'code_challenge' => $challenge,
+            'code_challenge_method' => 'S256',
+        ];
+
+        if ($promptNone) {
+            $query['prompt'] = 'none';
+        }
+
+        if ($params->get('locale')) {
+            [$locale] = explode('-', Factory::getApplication()->getLanguage()->getTag());
+            $query['ui_locales'] = $locale;
+        }
+
+        $separator = str_contains((string) $discovery['authorization_endpoint'], '?') ? '&' : '?';
+
+        return $discovery['authorization_endpoint'] . $separator . http_build_query($query);
+    }
+
+    /**
+     * Lightweight reachability probe for an OIDC IdP: GET the discovery
+     * document at <issuer>/.well-known/openid-configuration.
+     * On success, warms the discovery cache so the following
+     * buildAuthorizationUrl() call does not re-fetch the same document.
+     *
+     * @param Registry $params
+     */
+    private function verifyServerIsAlive($params): bool
+    {
+        $issuer = rtrim((string) $params->get('issuer'), '/');
+
+        if ($issuer === '') {
+            return false;
+        }
+
+        try {
+            $http = (new HttpFactory())->getHttp();
+            $timeout = (int) $params->get('timeout', 5);
+            $response = $http->get($issuer . '/.well-known/openid-configuration', [], $timeout);
+
+            if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 400) {
+                return false;
+            }
+
+            $document = json_decode((string) $response->getBody(), true);
+
+            if (
+                is_array($document)
+                && !empty($document['authorization_endpoint'])
+                && !empty($document['token_endpoint'])
+                && !empty($document['jwks_uri'])
+            ) {
+                $cache = $this->getCacheController();
+                $cache->cache->store(json_encode($document), 'discovery.' . md5($issuer));
+            }
+
+            return true;
+        } catch (Throwable $e) {
+            $this->log(
+                $params,
+                'log_verify',
+                'system-oidclogin-verify',
+                'HTTP error while verifying server is alive: ' . $e->getMessage(),
+                Log::WARNING
+            );
+
+            return false;
+        }
+    }
+
+    /**
      * Fetch (and cache) the OIDC discovery document for a server's issuer.
      *
      * @param Registry $params
@@ -1077,8 +1249,8 @@ class Oidclogin extends CMSPlugin
     }
 
     /**
-     * Log a message when the given server parameter toggle is enabled,
-     * mirroring Caslogin's log_* pattern.
+     * Log a message when the given server parameter toggle is enabled
+     * (per-server log_* flags such as log_autologin, log_login, …).
      *
      * @param Registry $params
      */


### PR DESCRIPTION
## Summary

Implements OIDC autologin for published servers (#241), completing the OIDC implementation epic (#236).

- **`autologin` toggle** (default off, already on the Connection fieldset) drives a guest-only `onAfterInitialise` redirect to a published, autologin-enabled OIDC server.
- **Reachability probe** GETs `<issuer>/.well-known/openid-configuration` before redirecting; a failed probe skips that server (and warms the discovery cache on success so the auth URL build does not re-fetch).
- **Once-per-session guard** via `system.oidclogin.autologin.{id}` — no redirect loop if the IdP is down or the visitor has no IdP session (`prompt=none` → `error=login_required`).
- **`log_autologin`** independently logs try/fail paths.
- **e2e**: guest visit with autologin on hits Keycloak’s authorize endpoint with `prompt=none` without clicking a login button; a second visit in the same session does not re-hit the IdP.

Silent SSO uses OIDC `prompt=none` (silent authentication when the IdP already has a session).

Also documents the devcontainer deploy gotcha: run `cache:clean` as `www-data` so root-owned language cache does not 500 the admin UI.

## Test plan

- [x] `composer run lint` / `phpstan` / `phpunit` (49 tests)
- [x] e2e `should redirect guest to IdP when OIDC autologin is enabled`
- [x] e2e full OIDC suite (`oidc.spec.ts` — 7 tests)
- [x] Manual: enable Automatic login on Keycloak OIDC, visit site while already logged into Keycloak → silent Joomla login
- [x] Manual: enable Automatic login with no IdP session → bounce back as guest, no loop

Closes #241
Closes #236