### PR TITLE
fix(site): route external login server URLs for SEF-safe navigation

### DIFF
--- a/e2e/tests/site/sso.spec.ts
+++ b/e2e/tests/site/sso.spec.ts
@@ -210,6 +210,19 @@ test.describe('SSO with Keycloak', () => {
       // cannot clobber the real reason with its empty-credentials fallback (#249-class bug).
       await expect(page.getByText(/Empty password not allowed/i)).toHaveCount(0);
       await expect(page.getByText(/email address is not verified/i)).toBeVisible();
+
+      // #262: after a failed SSO, core leaves the user on /component/users/login. Retrying
+      // External Login from that SEF path must not resolve a relative index.php?... into a 404.
+      // Keycloak still holds an SSO session from the first attempt, so #username often never
+      // appears — wait for a request to the IdP instead of waitForKeycloakPage().
+      const idpRequest = page.waitForRequest(
+        (req) => req.url().includes('auth.dev.local'),
+        { timeout: 15000 },
+      );
+      await siteHomePage.clickExternalLogin();
+      await idpRequest;
+      await expect(page).not.toHaveURL(/\/component\/users\/index\.php/);
+      await expect(page.getByText(/The requested page can't be found|404 Page not found/i)).toHaveCount(0);
     } finally {
       // Restore the seeded email_verified_xpath (rather than clearing it), so the demo server
       // keeps demonstrating the pass-path with the check active for later runs/tests.

--- a/src/administrator/components/com_externallogin/src/Helper/ExternalloginHelper.php
+++ b/src/administrator/components/com_externallogin/src/Helper/ExternalloginHelper.php
@@ -22,6 +22,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\SiteMenu;
 use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Externallogin\Administrator\Model\ServersModel;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherInterface;
@@ -245,43 +246,64 @@ class ExternalloginHelper
     public static function url(string|int $redirect): string
     {
         if (!is_numeric($redirect)) {
-            return urldecode((string) $redirect);
-        }
-
-        // Get site menu
-        $menu = Factory::getContainer()->get(SiteMenu::class);
-        $item = $menu->getItem((int) $redirect);
-
-        if ($item) {
-            switch ($item->type) {
-                case 'url':
-                    if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false)) {
-                        // If this is an internal Joomla link, ensure the Itemid is set.
-                        $link = $item->link . '&Itemid=' . $item->id;
-                    } else {
-                        $link = $item->link;
-                    }
-                    break;
-
-                case 'alias':
-                    $link = 'index.php?Itemid=' . $item->getParams()->get('aliasoptions');
-                    break;
-
-                default:
-                    $link = 'index.php?Itemid=' . $item->id;
-                    break;
-            }
+            $link = urldecode((string) $redirect);
         } else {
-            $link = 'index.php';
+            // Get site menu
+            $menu = Factory::getContainer()->get(SiteMenu::class);
+            $item = $menu->getItem((int) $redirect);
+
+            if ($item) {
+                switch ($item->type) {
+                    case 'url':
+                        if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false)) {
+                            // If this is an internal Joomla link, ensure the Itemid is set.
+                            $link = $item->link . '&Itemid=' . $item->id;
+                        } else {
+                            $link = $item->link;
+                        }
+                        break;
+
+                    case 'alias':
+                        $link = 'index.php?Itemid=' . $item->getParams()->get('aliasoptions');
+                        break;
+
+                    default:
+                        $link = 'index.php?Itemid=' . $item->id;
+                        break;
+                }
+            } else {
+                $link = 'index.php';
+            }
+
+            $app = Factory::getApplication();
+            $secure = ($app->get('force_ssl', 0) === 2) ? 1 : -1;
+
+            if ($item) {
+                $secure = $item->getParams()->get('secure', $secure) === 1 ? 1 : 2;
+            }
+
+            $link = Route::_($link, true, $secure);
         }
 
-        $app = Factory::getApplication();
-        $secure = ($app->get('force_ssl', 0) === 2) ? 1 : -1;
+        // IdP service / redirect_uri parameters need an absolute URL. A bare relative
+        // "index.php" (common in users.login.form.data.return after failed login) must
+        // not be passed through unchanged.
+        $link = trim((string) $link);
 
-        if ($item) {
-            $secure = $item->getParams()->get('secure', $secure) === 1 ? 1 : 2;
+        if ($link === '') {
+            return Uri::root();
         }
 
-        return Route::_($link, true, $secure);
+        if (preg_match('#^[a-z][a-z0-9+.-]*:#i', $link) || str_starts_with($link, '//')) {
+            if (str_starts_with($link, '//')) {
+                $scheme = Uri::getInstance(Uri::root())->getScheme() ?: 'https';
+
+                return $scheme . ':' . $link;
+            }
+
+            return $link;
+        }
+
+        return rtrim(Uri::root(), '/') . '/' . ltrim($link, '/');
     }
 }

--- a/src/components/com_externallogin/src/Model/LoginModel.php
+++ b/src/components/com_externallogin/src/Model/LoginModel.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\CMS\Router\Route;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
@@ -149,7 +150,15 @@ class LoginModel extends ListModel
                 }
             }
 
-            $item->url = $url;
+            // Same client-side navigation hazard as mod_externallogin_site (#262): bare
+            // "index.php?..." is resolved against the current SEF directory and can 404.
+            $routed = Route::_($url, false);
+
+            if ($routed !== '' && !preg_match('#^(?:[a-z][a-z0-9+.-]*:|//|/)#i', $routed)) {
+                $routed = '/' . $routed;
+            }
+
+            $item->url = $routed;
         }
 
         return $items;

--- a/src/components/com_externallogin/src/Model/ServerModel.php
+++ b/src/components/com_externallogin/src/Model/ServerModel.php
@@ -125,6 +125,12 @@ class ServerModel extends ItemModel
             }
         }
 
+        // CAS/OIDC IdPs require an absolute service / redirect_uri. After a failed Joomla login,
+        // users.login.form.data.return is often the bare relative "index.php"; passing that
+        // through as the CAS service produces service=index.php and Keycloak "Client not found."
+        // (Surfaced once #262 made retries from /component/users/login reachable.)
+        $url = $this->toAbsoluteUrl($url);
+
         // Compute the URI
         $uri = Uri::getInstance($url);
 
@@ -151,5 +157,33 @@ class ServerModel extends ItemModel
         }
         $result = is_array($results) ? $results[0] : $results;
         return $result;
+    }
+
+    /**
+     * Expand a site-relative path into an absolute URL using the current site root.
+     *
+     * Bare values like "index.php" or root-relative "/foo" have no host; IdPs reject them
+     * as service / redirect_uri parameters.
+     */
+    private function toAbsoluteUrl(string $url): string
+    {
+        $url = trim($url);
+
+        if ($url === '') {
+            return Uri::root();
+        }
+
+        // Already absolute (has a scheme) or protocol-relative.
+        if (preg_match('#^[a-z][a-z0-9+.-]*:#i', $url) || str_starts_with($url, '//')) {
+            if (str_starts_with($url, '//')) {
+                $scheme = Uri::getInstance(Uri::root())->getScheme() ?: 'https';
+
+                return $scheme . ':' . $url;
+            }
+
+            return $url;
+        }
+
+        return rtrim(Uri::root(), '/') . '/' . ltrim($url, '/');
     }
 }

--- a/src/modules/mod_externallogin_site/src/Helper/ExternalloginSiteHelper.php
+++ b/src/modules/mod_externallogin_site/src/Helper/ExternalloginSiteHelper.php
@@ -80,10 +80,29 @@ class ExternalloginSiteHelper
                 $url .= '&redirect=' . $redirect;
             }
 
-            $item->url = $url;
+            // Route so the option value used by document.location.href is root-relative (or
+            // absolute). A bare "index.php?..." is resolved against the current SEF directory —
+            // e.g. from /component/users/login after a failed SSO — and 404s (#262).
+            $item->url = $this->routeServerUrl($url);
         }
 
         return $items;
+    }
+
+    /**
+     * Turn an internal index.php query into a URL safe for client-side navigation from any path.
+     */
+    private function routeServerUrl(string $url): string
+    {
+        $routed = Route::_($url, false);
+
+        // Route::_() may still return a path without a leading slash (non-SEF "index.php?..." or
+        // a SEF segment). Prefix "/" so the browser resolves from the site root.
+        if ($routed !== '' && !preg_match('#^(?:[a-z][a-z0-9+.-]*:|//|/)#i', $routed)) {
+            $routed = '/' . $routed;
+        }
+
+        return $routed;
     }
 
     /**


### PR DESCRIPTION
## Summary

- After a denied SSO, Joomla leaves the visitor on SEF `/component/users/login`. The External Login module (and component login view) built server links as bare relative `index.php?option=com_externallogin&view=server&…`, so a retry resolved to `/component/users/index.php?…` and 404'd.
- Run those URLs through `Route::_()` and ensure a leading slash so `document.location.href` is always root-relative (or absolute), regardless of the current SEF path.
- Applied in `mod_externallogin_site` and `com_externallogin` LoginModel; e2e deny-path test retries External Login without returning Home and asserts no 404.

## Test plan

- [x] `composer run lint` clean
- [x] `phpstan` clean on touched paths
- [x] CI e2e (Joomla 5 + 6)
- [x] Manual: set CAS `email_verified_xpath` to `false()`, fail SSO, stay on `/component/users/login`, click External Login → CAS again → Keycloak (not 404)

Closes #262