### PR TITLE
chore: bump version to 5.2.0

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -32,10 +32,10 @@
 		<element>pkg_externallogin</element>
 		<type>package</type>
 		<client>site</client>
-		<version>5.1.0</version>
-		<infourl title="External Login">https://github.com/akunzai/joomla-external-login/releases/5.1.0</infourl>
+		<version>5.2.0</version>
+		<infourl title="External Login">https://github.com/akunzai/joomla-external-login/releases/5.2.0</infourl>
 		<downloads>
-			<downloadurl type="full" format="zip">https://github.com/akunzai/joomla-external-login/releases/download/5.1.0/pkg_externallogin.zip</downloadurl>
+			<downloadurl type="full" format="zip">https://github.com/akunzai/joomla-external-login/releases/download/5.2.0/pkg_externallogin.zip</downloadurl>
 		</downloads>
 		<targetplatform name="joomla" version="(5|6)" />
 	</update>

--- a/src/administrator/modules/mod_externallogin_admin/mod_externallogin_admin.xml
+++ b/src/administrator/modules/mod_externallogin_admin/mod_externallogin_admin.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>MOD_EXTERNALLOGIN_ADMIN_DESCRIPTION</description>

--- a/src/com_externallogin.xml
+++ b/src/com_externallogin.xml
@@ -12,7 +12,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>COM_EXTERNALLOGIN_DESCRIPTION</description>

--- a/src/modules/mod_externallogin_site/mod_externallogin_site.xml
+++ b/src/modules/mod_externallogin_site/mod_externallogin_site.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>MOD_EXTERNALLOGIN_SITE_DESCRIPTION</description>

--- a/src/pkg_externallogin.xml
+++ b/src/pkg_externallogin.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>PKG_EXTERNALLOGIN_DESCRIPTION</description>

--- a/src/plugins/authentication/externallogin/externallogin.xml
+++ b/src/plugins/authentication/externallogin/externallogin.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>PLG_AUTHENTICATION_EXTERNALLOGIN_DESCRIPTION</description>

--- a/src/plugins/system/caslogin/caslogin.xml
+++ b/src/plugins/system/caslogin/caslogin.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>PLG_SYSTEM_CASLOGIN_DESCRIPTION</description>

--- a/src/plugins/system/externallogin/externallogin.xml
+++ b/src/plugins/system/externallogin/externallogin.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>PLG_SYSTEM_EXTERNALLOGIN_DESCRIPTION</description>

--- a/src/plugins/system/oidclogin/oidclogin.xml
+++ b/src/plugins/system/oidclogin/oidclogin.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>PLG_SYSTEM_OIDCLOGIN_DESCRIPTION</description>

--- a/src/plugins/user/cbexternallogin/cbexternallogin.xml
+++ b/src/plugins/user/cbexternallogin/cbexternallogin.xml
@@ -10,7 +10,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE</license>
 
 	<!--  The version string is recorded in the extension table -->
-	<version>5.1.0</version>
+	<version>5.2.0</version>
 
 	<!-- The description is optional and defaults to the name -->
 	<description>PLG_USER_CBEXTERNALLOGIN_DESCRIPTION</description>


### PR DESCRIPTION
## Summary

- Bump package, component, modules, and plugins from **5.1.0** to **5.2.0**.
- Update `manifest.xml` (Joomla update server entry for platforms 5|6) to **5.2.0**.

No git tag and no GitHub Release in this PR — cut the tag when the release is ready so the update-site download URL exists.

## Test plan

- [x] Version strings only (`5.1.0` → `5.2.0`) across the extension manifests and update manifest
- [ ] After merge, when releasing: `git tag 5.2.0` / publish release / attach `pkg_externallogin.zip`