### PR TITLE
ci(e2e): pin tags, GHA cache warm, deepen Docker layers

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -83,8 +83,8 @@ services:
       - traefik.http.services.openmage.loadbalancer.server.port=8080
 
   mysql:
-    # https://hub.docker.com/_/mysql
-    image: mysql
+    # https://hub.docker.com/_/mysql — pin major.minor for reproducible CI pulls / cache hits
+    image: mysql:8.4
     volumes:
       - type: volume
         source: mysql_data
@@ -96,8 +96,8 @@ services:
       - 127.0.0.1:3306:3306
 
   traefik:
-    # https://hub.docker.com/_/traefik
-    image: traefik
+    # https://hub.docker.com/_/traefik — pin v3 line (same idea as mysql)
+    image: traefik:v3.7
     networks:
       default:
         aliases:

--- a/.devcontainer/docker-bake.hcl
+++ b/.devcontainer/docker-bake.hcl
@@ -1,0 +1,33 @@
+// Local parallel multi-target builds:
+//   docker buildx bake -f docker-bake.hcl --load
+//
+// CI uses docker/build-push-action with type=gha (see .github/workflows/e2e.yml).
+// Raw bake/buildx CLI type=gha does not export cache in GHA for this workflow.
+
+variable "JOOMLA_VERSION" {
+  default = "6.1.2"
+}
+
+variable "PHP_VERSION" {
+  default = "8.4"
+}
+
+group "default" {
+  targets = ["joomla", "keycloak"]
+}
+
+target "joomla" {
+  context    = "./joomla"
+  dockerfile = "Dockerfile"
+  tags       = ["joomla:external-login"]
+  args = {
+    JOOMLA_VERSION = JOOMLA_VERSION
+    PHP_VERSION    = PHP_VERSION
+  }
+}
+
+target "keycloak" {
+  context    = "./keycloak"
+  dockerfile = "Dockerfile"
+  tags       = ["keycloak:cas"]
+}

--- a/.devcontainer/joomla/Dockerfile
+++ b/.devcontainer/joomla/Dockerfile
@@ -3,10 +3,17 @@ ARG PHP_EXTRA_BUILD_DEPS=""
 # https://hub.docker.com/_/joomla
 ARG JOOMLA_VERSION=6.1.2
 
-FROM joomla:${JOOMLA_VERSION}-apache AS joomla
+# Joomla upstream tree only — changes to JOOMLA_VERSION must not rebuild PHP extensions.
+FROM joomla:${JOOMLA_VERSION}-apache AS joomla-src
 
+# -----------------------------------------------------------------------------
+# php-ext: expensive compile layer (docker-php-ext-install + PECL).
+# Cache key depends on PHP_VERSION / PHP_EXTRA_BUILD_DEPS / this stage only.
+# -----------------------------------------------------------------------------
 # https://hub.docker.com/_/php
-FROM php:${PHP_VERSION}-apache
+FROM php:${PHP_VERSION}-apache AS php-ext
+
+ARG PHP_EXTRA_BUILD_DEPS
 
 ENV LANG=en_US.UTF-8
 
@@ -15,9 +22,6 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
     set -eux; \
     apt-get update; \
-    # install the system tools we need
-    apt-get install -y --no-install-recommends git mariadb-client unzip rsync; \
-    # install the PHP extensions we need
     savedAptMark="$(apt-mark showmanual)"; \
     apt-get install -y --no-install-recommends \
     libfreetype6-dev libicu-dev libssl-dev \
@@ -29,13 +33,15 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp; \
     docker-php-ext-install -j$(nproc) ftp \
     gd intl mysqli opcache pcntl pdo_mysql soap xsl zip; \
-    curl -Lo /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/latest/download/pickle.phar && \
+    # Pin pickle release so this layer is reproducible (not floating "latest").
+    # https://github.com/FriendsOfPHP/pickle/releases
+    curl -fsSL -o /usr/local/bin/pickle \
+      https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.11/pickle.phar; \
     chmod +x /usr/local/bin/pickle; \
     pickle install --no-interaction apcu-stable; \
     pickle install --no-interaction redis-stable; \
     pickle install --no-interaction xdebug-stable; \
     docker-php-ext-enable apcu opcache redis xdebug; \
-    # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
     find /usr/local -type f -executable -exec ldd '{}' ';' 2>/dev/null \
@@ -49,28 +55,37 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /tmp/*;
 
+# -----------------------------------------------------------------------------
+# Runtime image: cheap layers on top of php-ext; JOOMLA_VERSION only hits the end.
+# -----------------------------------------------------------------------------
+FROM php-ext
+
+# Runtime OS tools (separate from extension compile so tool list changes stay cheap)
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends git mariadb-client unzip rsync; \
+    rm -rf /tmp/*;
+
 # set up Apache2
 RUN set -eux; \
-    # enable Apache2 modules
     a2enmod rewrite expires include deflate remoteip headers; \
     { \
-        # disable Apache2 server signature
         echo 'ServerSignature Off'; \
         echo 'ServerTokens Prod'; \
-        # enable support for TLS termination
         echo 'SetEnvIf X-Forwarded-Proto https HTTPS=on'; \
     } >> /etc/apache2/apache2.conf;
 
-# install composer
+# Pin major tag (not :latest) so COPY --from digest churn is limited.
 # https://hub.docker.com/_/composer
-COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
-# set up Joomla!
-# Disable remote database security requirements.
+# set up Joomla! (invalidates only from here when JOOMLA_VERSION changes)
 ENV JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK=1
-COPY --from=joomla /entrypoint.sh /
-COPY --from=joomla /makedb.php /
-COPY --from=joomla --chown=www-data:www-data /usr/src/joomla /usr/src/joomla
+COPY --from=joomla-src /entrypoint.sh /
+COPY --from=joomla-src /makedb.php /
+COPY --from=joomla-src --chown=www-data:www-data /usr/src/joomla /usr/src/joomla
 RUN set -eux; \
     chown -R www-data:www-data /usr/src/joomla; \
     chmod -R g+w /usr/src/joomla;

--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -6,14 +6,14 @@ FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}
 ARG KEYCLOAK_VERSION
 ARG KEYCLOAK_CAS_VERSION
 
-# Install microcheck for healthcheck
-# https://github.com/tarampampam/microcheck
-COPY --from=ghcr.io/tarampampam/microcheck:1 /bin/httpscheck /bin/httpscheck
-
-# add CAS protocol for Keycloak
+# CAS provider + kc.sh build first (expensive). Keep healthcheck binary after so
+# microcheck image updates do not invalidate the Keycloak build layer.
 # https://github.com/jacekkow/keycloak-protocol-cas
 ADD --chown=keycloak:keycloak https://github.com/jacekkow/keycloak-protocol-cas/releases/download/${KEYCLOAK_CAS_VERSION}/keycloak-protocol-cas-${KEYCLOAK_CAS_VERSION}.jar /opt/keycloak/providers/keycloak-protocol-cas.jar
 
 WORKDIR /opt/keycloak
 
 RUN /opt/keycloak/bin/kc.sh build --health-enabled=true
+
+# https://github.com/tarampampam/microcheck
+COPY --from=ghcr.io/tarampampam/microcheck:1 /bin/httpscheck /bin/httpscheck

--- a/.github/workflows/e2e-image-cache.yml
+++ b/.github/workflows/e2e-image-cache.yml
@@ -1,0 +1,74 @@
+# Warm GHA BuildKit caches for e2e custom images on main so new PRs can
+# cache-from on their first run (PR jobs may restore caches from the default branch).
+# Scopes must match .github/workflows/e2e.yml (joomla-5 / joomla-6 / keycloak).
+name: E2E Image Cache
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.devcontainer/joomla/**'
+      - '.devcontainer/keycloak/**'
+      - '.github/workflows/e2e-image-cache.yml'
+      - '.github/workflows/e2e.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warm-joomla:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        joomla:
+          - version: "5"
+            php-version: "8.3"
+            joomla-version: "5.4.7"
+          - version: "6"
+            php-version: "8.4"
+            joomla-version: "6.1.2"
+    name: Warm Joomla ${{ matrix.joomla.version }} cache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # No load/push — only export type=gha layers for PR e2e cache-from.
+      - name: Build Joomla image (cache export)
+        uses: docker/build-push-action@v7
+        with:
+          context: .devcontainer/joomla
+          build-args: |
+            JOOMLA_VERSION=${{ matrix.joomla.joomla-version }}
+            PHP_VERSION=${{ matrix.joomla.php-version }}
+          cache-from: type=gha,scope=joomla-${{ matrix.joomla.version }}
+          cache-to: type=gha,mode=max,scope=joomla-${{ matrix.joomla.version }}
+
+  warm-keycloak:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Warm Keycloak cache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Keycloak image (cache export)
+        uses: docker/build-push-action@v7
+        with:
+          context: .devcontainer/keycloak
+          cache-from: type=gha,scope=keycloak
+          cache-to: type=gha,mode=max,scope=keycloak

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,8 @@ on:
 
 permissions:
   contents: read
+  # buildx type=gha cache-to needs write on private repos; harmless on public
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -31,12 +33,13 @@ jobs:
       fail-fast: false
       matrix:
         joomla:
+          # Always set build-args so Joomla 6 is not a special empty case.
           - version: "5"
             php-version: "8.3"
             joomla-version: "5.4.7"
           - version: "6"
-            php-version: ""
-            joomla-version: ""
+            php-version: "8.4"
+            joomla-version: "6.1.2"
     name: E2E (Joomla ${{ matrix.joomla.version }})
     steps:
       - name: Checkout
@@ -54,13 +57,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # type=gha only persists reliably via docker/build-push-action (or bake-action).
+      # Scopes match .github/workflows/e2e-image-cache.yml (main warms caches for
+      # first-run PRs; PR jobs can restore from the default branch).
+      - name: Pull service images
+        working-directory: .devcontainer
+        # Tags come from compose.yml (SSOT); only Hub services — not joomla/keycloak.
+        run: docker compose pull mysql traefik
+
       - name: Build Joomla image
         uses: docker/build-push-action@v7
         with:
           context: .devcontainer/joomla
           build-args: |
-            ${{ matrix.joomla.joomla-version != '' && format('JOOMLA_VERSION={0}', matrix.joomla.joomla-version) || '' }}
-            ${{ matrix.joomla.php-version != '' && format('PHP_VERSION={0}', matrix.joomla.php-version) || '' }}
+            JOOMLA_VERSION=${{ matrix.joomla.joomla-version }}
+            PHP_VERSION=${{ matrix.joomla.php-version }}
           load: true
           tags: joomla:external-login
           cache-from: type=gha,scope=joomla-${{ matrix.joomla.version }}


### PR DESCRIPTION
## Summary

Speeds up E2E (including first-run PRs after main is warm) without changing test coverage:

- **GHA layer cache** — `docker/build-push-action@v7` with scopes `joomla-5` / `joomla-6` / `keycloak` (raw buildx CLI `type=gha` did not export in CI).
- **Warm on `main`** — `.github/workflows/e2e-image-cache.yml` exports the same scopes on push / `workflow_dispatch` so new PRs can restore default-branch caches.
- **Deeper Docker layers**
  - **Joomla:** `php-ext` stage holds expensive `docker-php-ext-install` + PECL; runtime apt tools, Apache, `composer:2`, and Joomla tree are later layers so `JOOMLA_VERSION` bumps do not recompile PHP.
  - **Keycloak:** `kc.sh build` before microcheck `COPY` so healthcheck image updates do not rebuild Keycloak.
  - Pin pickle `v0.7.11` (not floating latest).
- **Hub pulls** — `docker compose pull mysql traefik` (tags SSOT in compose).
- **Pinned tags** — `mysql:8.4`, `traefik:v3.7`; explicit Joomla 6.1.2 / PHP 8.4 build-args.
- **`actions: write`** for `cache-to: type=gha`.
- **Local** — `.devcontainer/docker-bake.hcl` for `docker buildx bake --load` only.

## Test plan

- [x] CI E2E (Joomla 5) green
- [x] CI E2E (Joomla 6) green
- [x] Build logs: `exporting to GitHub Actions Cache`
- [x] After merge / manual **E2E Image Cache** on main: new PR first image builds import gha when Dockerfiles unchanged
- [x] Bumping only `JOOMLA_VERSION` reuses `php-ext` layer (no full PHP recompile)
- [ ] Local: `docker buildx bake -f .devcontainer/docker-bake.hcl --load`