### PR TITLE
fix(security): block open redirect and escape server titles

### DIFF
--- a/src/administrator/components/com_externallogin/src/Helper/ExternalloginHelper.php
+++ b/src/administrator/components/com_externallogin/src/Helper/ExternalloginHelper.php
@@ -245,7 +245,11 @@ class ExternalloginHelper
      */
     public static function url(string|int $redirect): string
     {
-        if (!is_numeric($redirect)) {
+        // Non-numeric values come from request (e.g. ?redirect=https://…); menu Itemids are
+        // admin-configured and may intentionally point at an external "url" menu type.
+        $fromUntrustedString = !is_numeric($redirect);
+
+        if ($fromUntrustedString) {
             $link = urldecode((string) $redirect);
         } else {
             // Get site menu
@@ -297,8 +301,14 @@ class ExternalloginHelper
         if (preg_match('#^[a-z][a-z0-9+.-]*:#i', $link) || str_starts_with($link, '//')) {
             if (str_starts_with($link, '//')) {
                 $scheme = Uri::getInstance(Uri::root())->getScheme() ?: 'https';
+                $link = $scheme . ':' . $link;
+            }
 
-                return $scheme . ':' . $link;
+            // Untrusted absolute URLs (e.g. ?redirect=https://evil.example/) must not become
+            // open redirects or IdP service/redirect_uri targets. Same bar as the HTTP_REFERER
+            // fallback in Site\Model\ServerModel::getItem().
+            if ($fromUntrustedString && !Uri::isInternal($link)) {
+                return Uri::root();
             }
 
             return $link;

--- a/src/administrator/modules/mod_externallogin_admin/tmpl/alone.php
+++ b/src/administrator/modules/mod_externallogin_admin/tmpl/alone.php
@@ -21,11 +21,11 @@ if ($servers === []) {
     return;
 }
 ?>
-<h4><?php echo $servers[0]->title; ?></h4>
+<h4><?php echo htmlspecialchars($servers[0]->title, ENT_QUOTES, 'UTF-8'); ?></h4>
 <div class="control-group">
 	<div class="controls">
 		<div class="btn-group pull-left">
-			<button tabindex="3" class="btn btn-primary btn-large" onclick="document.location.href='<?php echo $servers[0]->url; ?>'; return false;">
+			<button tabindex="3" class="btn btn-primary btn-large" onclick="document.location.href='<?php echo htmlspecialchars($servers[0]->url, ENT_QUOTES, 'UTF-8'); ?>'; return false;">
 				<i class="icon-lock icon-white"></i> <?php echo Text::_('MOD_EXTERNALLOGIN_ADMIN_LOGIN'); ?>
 			</button>
 		</div>

--- a/src/administrator/modules/mod_externallogin_admin/tmpl/form.php
+++ b/src/administrator/modules/mod_externallogin_admin/tmpl/form.php
@@ -23,7 +23,7 @@ $servers ??= [];
 <select id="mod-server-login-<?php echo $module->id; ?>">
 	<option value=""><?php echo Text::_('MOD_EXTERNALLOGIN_ADMIN_SELECT_OPTION'); ?></option>
 	<?php foreach ($servers as $server) : ?>
-		<option value="<?php echo htmlspecialchars($server->url, ENT_COMPAT, 'UTF-8'); ?>"><?php echo $server->title; ?></option>
+		<option value="<?php echo htmlspecialchars($server->url, ENT_COMPAT, 'UTF-8'); ?>"><?php echo htmlspecialchars($server->title, ENT_QUOTES, 'UTF-8'); ?></option>
 	<?php endforeach; ?>
 </select>
 <div class="clr"></div>

--- a/src/components/com_externallogin/tmpl/login/default_login.php
+++ b/src/components/com_externallogin/tmpl/login/default_login.php
@@ -53,7 +53,7 @@ HTMLHelper::_('behavior.keepalive');
 				<select id="server-login">
 					<option value=""><?php echo Text::_('COM_EXTERNALLOGIN_SELECT_OPTION'); ?></option>
 					<?php foreach ($this->items as $server) : ?>
-						<option value="<?php echo htmlspecialchars($server->url, ENT_COMPAT, 'UTF-8'); ?>"><?php echo $server->title; ?></option>
+						<option value="<?php echo htmlspecialchars($server->url, ENT_COMPAT, 'UTF-8'); ?>"><?php echo htmlspecialchars($server->title, ENT_QUOTES, 'UTF-8'); ?></option>
 					<?php endforeach; ?>
 				</select>
 				<div class="clr"></div>

--- a/src/modules/mod_externallogin_site/tmpl/alone.php
+++ b/src/modules/mod_externallogin_site/tmpl/alone.php
@@ -26,6 +26,6 @@ if ($servers === []) {
 }
 ?>
 <?php if ($params->get('show_title', 0)) : ?>
-	<h4><?php echo $servers[0]->title; ?></h4>
+	<h4><?php echo htmlspecialchars($servers[0]->title, ENT_QUOTES, 'UTF-8'); ?></h4>
 <?php endif; ?>
-<input type="submit" class="btn btn-primary" onclick="document.location.href='<?php echo $servers[0]->url; ?>';return false;" class="button" value="<?php echo htmlspecialchars(Text::_('JLOGIN'), ENT_COMPAT, 'UTF-8'); ?>" />
+<input type="submit" class="btn btn-primary" onclick="document.location.href='<?php echo htmlspecialchars($servers[0]->url, ENT_QUOTES, 'UTF-8'); ?>';return false;" class="button" value="<?php echo htmlspecialchars(Text::_('JLOGIN'), ENT_COMPAT, 'UTF-8'); ?>" />

--- a/src/modules/mod_externallogin_site/tmpl/form.php
+++ b/src/modules/mod_externallogin_site/tmpl/form.php
@@ -23,7 +23,7 @@ $servers ??= [];
 <select id="mod-server-login-<?php echo $module->id; ?>" class="span">
 	<option value=""><?php echo Text::_('MOD_EXTERNALLOGIN_SITE_SELECT_OPTION'); ?></option>
 	<?php foreach ($servers as $server) : ?>
-		<option value="<?php echo htmlspecialchars($server->url, ENT_COMPAT, 'UTF-8'); ?>"><?php echo $server->title; ?></option>
+		<option value="<?php echo htmlspecialchars($server->url, ENT_COMPAT, 'UTF-8'); ?>"><?php echo htmlspecialchars($server->title, ENT_QUOTES, 'UTF-8'); ?></option>
 	<?php endforeach; ?>
 </select>
 <div class="clr"></div>


### PR DESCRIPTION
## Summary

Fixes the two **HIGH** findings from the security audit of this repo:

1. **Open redirect / IdP service URL injection (F-01)**  
   `ExternalloginHelper::url()` now rejects **untrusted** absolute URLs (from non-numeric `redirect=` strings) unless `Uri::isInternal()` passes — same bar as the `HTTP_REFERER` fallback in `ServerModel`. Menu Itemids remain admin-configured and may still resolve to external “url” menu types.

2. **Stored XSS via server title (F-02)**  
   Escape `$server->title` (and alone-module login URLs in attribute/JS context) on site login view and site/admin external-login modules.

## Test plan

- [ ] `composer test` (or CI PHPUnit) green
- [ ] Logged-in: `…/view=server&server=1&redirect=https://evil.example/` stays on site root (no 302 to evil)
- [ ] Guest SSO start with internal return / menu Itemid still works
- [ ] Server title with `<script>` renders as text on login module / login view
- [ ] CI E2E green