### PR TITLE
docs: 5.2 upgrade notes and phpstan memory limit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ docker compose -f .devcontainer/compose.yml exec -w /workspace joomla <command>
 composer install
 composer run lint       # php-cs-fixer dry-run
 composer run fix
-composer run phpstan
+composer run phpstan    # includes --memory-limit=512M (default 128M OOMs on this tree)
+composer test
 ./bundle.sh             # → dist/pkg_externallogin.zip
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ composer install
 # check coding style
 composer run lint
 
-# static code analysis
+# static code analysis (phpstan is configured with --memory-limit=512M in composer.json)
 composer run phpstan
+
+# unit tests
+composer test
 
 # bundle the Joomla! extension. The `pkg_externallogin.zip` can be found in the `dist/` directory
 ./bundle.sh
@@ -42,11 +45,19 @@ Navigate to `System->Install->Extensions` in Joomla! backend and upload the pack
 
 > You can get notified once a new version is released and update this extension through Joomla! admin UI
 
+## Upgrading to 5.2
+
+1. Upload `pkg_externallogin.zip` over the existing package (or use Joomla Update when available).
+2. **Enable** the new plugin **System - OIDC Login** if you will use OpenID Connect (`System → Plugins`).
+3. **PHP ≥ 8.3** is required (8.1/8.2 are no longer supported).
+4. **OIDC only:** when `username_claim` is `email` (the default), the IdP must send `email_verified=true`, or enable **Allow unverified email** on the server. CAS behaviour is unchanged unless you set `email_verified_xpath`.
+5. See **[known limitations](docs/known-limitations.md)** for claim mapping (Keycloak roles, Azure AD groups) and related operator notes.
+
 ## Known limitations
 
-Full write-ups: **[docs/known-limitations.md](docs/known-limitations.md)**. Rebinding a user to another server: **[docs/server-binding.md](docs/server-binding.md)**.
+Full write-ups: **[docs/known-limitations.md](docs/known-limitations.md)**.
 
-- **One server per account** — login via a different CAS/OIDC server is rejected until an admin rebinds the account ([howto](docs/server-binding.md), [ADR 0001](docs/adr/0001-one-account-binds-one-external-login-server.md)).
+- **One server per account** — login via a different CAS/OIDC server is rejected until an admin rebinds the account ([server-binding.md](docs/server-binding.md)).
 - **Keycloak role claims** — enable “Add to userinfo/ID token” on the built-in roles mappers; the plugin never reads the access token.
 - **OIDC `username_claim` defaults to `email`** — matches CAS’s email-based username; requires `email_verified=true` unless **Allow unverified email** is enabled (see doc).
 - **CAS email verification is opt-in** — optional `email_verified_xpath` (XPath cookbook in the doc).

--- a/composer.json
+++ b/composer.json
@@ -80,10 +80,10 @@
 			"php-cs-fixer fix"
 		],
 		"phpstan": [
-			"phpstan analyse"
+			"phpstan analyse --memory-limit=512M"
 		],
 		"phpstan-baseline": [
-			"phpstan analyse --generate-baseline"
+			"phpstan analyse --memory-limit=512M --generate-baseline"
 		],
 		"test": [
 			"phpunit"


### PR DESCRIPTION
## Summary

Pre-release hygiene for **5.2** (OIDC is the headline feature):

- `composer run phpstan` / `phpstan-baseline` use `--memory-limit=512M` (default 128M OOMs on this tree)
- README **Upgrading to 5.2** short section (enable OIDC plugin, PHP 8.3+, email_verified behaviour)
- Explicitly rely on **GitHub Releases** for notes rather than a repo CHANGELOG
- AGENTS.md quick command note

## Test plan

- [x] `composer run phpstan` completes with No errors
- [x] README upgrade section accurate for 5.1 → 5.2 operators