### PR TITLE
chore: upgrade Joomla to 6.1.3 and 5.4.8

### DIFF
--- a/.devcontainer/docker-bake.hcl
+++ b/.devcontainer/docker-bake.hcl
@@ -5,7 +5,7 @@
 // Raw bake/buildx CLI type=gha does not export cache in GHA for this workflow.
 
 variable "JOOMLA_VERSION" {
-  default = "6.1.2"
+  default = "6.1.3"
 }
 
 variable "PHP_VERSION" {

--- a/.devcontainer/joomla/Dockerfile
+++ b/.devcontainer/joomla/Dockerfile
@@ -1,7 +1,7 @@
 ARG PHP_VERSION=8.4
 ARG PHP_EXTRA_BUILD_DEPS=""
 # https://hub.docker.com/_/joomla
-ARG JOOMLA_VERSION=6.1.2
+ARG JOOMLA_VERSION=6.1.3
 
 # Joomla upstream tree only — changes to JOOMLA_VERSION must not rebuild PHP extensions.
 FROM joomla:${JOOMLA_VERSION}-apache AS joomla-src

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,13 +5,13 @@ bug:
 refactor:
   - head-branch: ['^refactor/']
 dependencies:
-  - head-branch: ['^dependabot/', '^keycloak/']
+  - head-branch: ['^dependabot/', '^keycloak/', '^joomla/']
   - changed-files:
       - any-glob-to-any-file:
           - 'composer.json'
           - 'composer.lock'
           - 'e2e/package.json'
-          - 'e2e/package-lock.json'
+          - 'e2e/pnpm-lock.yaml'
 github_actions:
   - head-branch: ['^ci/']
   - changed-files:

--- a/.github/workflows/e2e-image-cache.yml
+++ b/.github/workflows/e2e-image-cache.yml
@@ -32,10 +32,10 @@ jobs:
         joomla:
           - version: "5"
             php-version: "8.3"
-            joomla-version: "5.4.7"
+            joomla-version: "5.4.8"
           - version: "6"
             php-version: "8.4"
-            joomla-version: "6.1.2"
+            joomla-version: "6.1.3"
     name: Warm Joomla ${{ matrix.joomla.version }} cache
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,10 +36,10 @@ jobs:
           # Always set build-args so Joomla 6 is not a special empty case.
           - version: "5"
             php-version: "8.3"
-            joomla-version: "5.4.7"
+            joomla-version: "5.4.8"
           - version: "6"
             php-version: "8.4"
-            joomla-version: "6.1.2"
+            joomla-version: "6.1.3"
     name: E2E (Joomla ${{ matrix.joomla.version }})
     steps:
       - name: Checkout

--- a/.github/workflows/update-joomla-docker.yml
+++ b/.github/workflows/update-joomla-docker.yml
@@ -62,7 +62,10 @@ jobs:
           NEW_VERSION: ${{ steps.get-version.outputs.latest_6 }}
         run: |
           sed -i "s/ARG JOOMLA_VERSION=${CURRENT_VERSION}/ARG JOOMLA_VERSION=${NEW_VERSION}/" .devcontainer/joomla/Dockerfile
+          sed -i "s/default = \"${CURRENT_VERSION}\"/default = \"${NEW_VERSION}\"/" .devcontainer/docker-bake.hcl
           sed -i "s/${CURRENT_VERSION}/${NEW_VERSION}/g" composer.json
+          sed -i "s/joomla-version: \"${CURRENT_VERSION}\"/joomla-version: \"${NEW_VERSION}\"/" .github/workflows/e2e.yml
+          sed -i "s/joomla-version: \"${CURRENT_VERSION}\"/joomla-version: \"${NEW_VERSION}\"/" .github/workflows/e2e-image-cache.yml
 
       - name: Set up PHP
         if: steps.get-version.outputs.needs_update_6 == 'true'
@@ -83,6 +86,7 @@ jobs:
           NEW_VERSION: ${{ steps.get-version.outputs.latest_5 }}
         run: |
           sed -i "s/joomla-version: \"${CURRENT_VERSION}\"/joomla-version: \"${NEW_VERSION}\"/" .github/workflows/e2e.yml
+          sed -i "s/joomla-version: \"${CURRENT_VERSION}\"/joomla-version: \"${NEW_VERSION}\"/" .github/workflows/e2e-image-cache.yml
 
       - name: Build PR metadata
         id: pr-meta
@@ -116,7 +120,7 @@ jobs:
           body: |
             Bump the `joomla` Docker image (https://hub.docker.com/_/joomla) used for development, CI, and E2E testing.
 
-            ${{ steps.get-version.outputs.needs_update_6 == 'true' && format('- Joomla 6: `{0}` → `{1}` (Dockerfile default, composer.json)', steps.get-version.outputs.current_6, steps.get-version.outputs.latest_6) || '' }}
+            ${{ steps.get-version.outputs.needs_update_6 == 'true' && format('- Joomla 6: `{0}` → `{1}` (Dockerfile default, docker-bake.hcl, composer.json, E2E matrix)', steps.get-version.outputs.current_6, steps.get-version.outputs.latest_6) || '' }}
             ${{ steps.get-version.outputs.needs_update_5 == 'true' && format('- Joomla 5: `{0}` → `{1}` (E2E matrix leg)', steps.get-version.outputs.current_5, steps.get-version.outputs.latest_5) || '' }}
 
             References:

--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,15 @@
 			"type": "package",
 			"package": {
 				"name": "joomla/joomla-cms",
-				"version": "6.1.2",
+				"version": "6.1.3",
 				"dist": {
-					"url": "https://github.com/joomla/joomla-cms/releases/download/6.1.2/Joomla_6.1.2-Stable-Full_Package.zip",
+					"url": "https://github.com/joomla/joomla-cms/releases/download/6.1.3/Joomla_6.1.3-Stable-Full_Package.zip",
 					"type": "zip"
 				},
 				"source": {
 					"url": "https://github.com/joomla/joomla-cms.git",
 					"type": "git",
-					"reference": "tags/6.1.2"
+					"reference": "tags/6.1.3"
 				}
 			}
 		}
@@ -45,7 +45,7 @@
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^3.95",
-		"joomla/joomla-cms": "6.1.2",
+		"joomla/joomla-cms": "6.1.3",
 		"phpstan/extension-installer": "^1.4",
 		"phpstan/phpstan": "^2.1",
 		"phpstan/phpstan-deprecation-rules": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bdaf30b068de0b372b2cf86b74735f9",
+    "content-hash": "f530826d944d067348f8931d77547e83",
     "packages": [],
     "packages-dev": [
         {
@@ -574,15 +574,15 @@
         },
         {
             "name": "joomla/joomla-cms",
-            "version": "6.1.2",
+            "version": "6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla/joomla-cms.git",
-                "reference": "tags/6.1.2"
+                "reference": "tags/6.1.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/joomla/joomla-cms/releases/download/6.1.2/Joomla_6.1.2-Stable-Full_Package.zip"
+                "url": "https://github.com/joomla/joomla-cms/releases/download/6.1.3/Joomla_6.1.3-Stable-Full_Package.zip"
             },
             "type": "library"
         },


### PR DESCRIPTION
Bump the `joomla` Docker image (https://hub.docker.com/_/joomla) used for development, CI, and E2E testing, and update the automated update workflow to keep all referenced configuration files in sync.

- Joomla 6: `6.1.2` → `6.1.3` (Dockerfile default, docker-bake.hcl, composer.json, E2E matrix)
- Joomla 5: `5.4.7` → `5.4.8` (E2E matrix leg)
- Workflows & tooling:
  - Update `.github/workflows/update-joomla-docker.yml` to also bump `docker-bake.hcl` and `e2e-image-cache.yml` / `e2e.yml` matrix versions.
  - Update `.github/labeler.yml` to recognize `^joomla/` branches and `pnpm-lock.yaml` for dependency labeling.

References:
- https://github.com/joomla/joomla-cms/releases/tag/6.1.3
- https://github.com/joomla/joomla-cms/releases/tag/5.4.8